### PR TITLE
Handle invalid bit depth in WAV writers

### DIFF
--- a/music/core/io.py
+++ b/music/core/io.py
@@ -75,8 +75,9 @@ def write_wav_mono(sonic_vector=SONIC_VECTOR_MONO, filename="asound.wav",
         result = adsr(attack_duration=fades[0], sustain_level=0,
                       release_duration=fades[1], sonic_vector=result)
     if bit_depth not in (8, 16, 32, 64):
-        print("bit_depth values allowed are only 8, 16, 32 and 64")
-        print(f"File {filename} not written")
+        raise ValueError(
+            "bit_depth values allowed are only 8, 16, 32 and 64"
+        )
     nn = eval("np.int" + str(bit_depth))
     result = nn(result)
     wavfile.write(filename, sample_rate, result)
@@ -122,8 +123,9 @@ def write_wav_stereo(sonic_vector=SONIC_VECTOR_STEREO, filename="asound.wav",
         result = adsr_stereo(attack_duration=fades[0], sustain_level=0,
                              release_duration=fades[1], sonic_vector=result)
     if bit_depth not in (8, 16, 32, 64):
-        print("bit_depth values allowed are only 8, 16, 32 and 64")
-        print(f"File {filename} not written")
+        raise ValueError(
+            "bit_depth values allowed are only 8, 16, 32 and 64"
+        )
     nn = eval("np.int" + str(bit_depth))
     result = nn(result)
     wavfile.write(filename, sample_rate, result.T)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,19 @@
+import numpy as np
+import sys
+from pathlib import Path
+import pytest
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+import music
+
+
+def test_invalid_bit_depth_mono():
+    with pytest.raises(ValueError):
+        music.write_wav_mono(np.zeros(10), filename="tmp.wav", bit_depth=24)
+
+
+def test_invalid_bit_depth_stereo():
+    with pytest.raises(ValueError):
+        music.write_wav_stereo(np.zeros((2, 10)), filename="tmp.wav", bit_depth=24)


### PR DESCRIPTION
## Summary
- raise `ValueError` when unsupported bit depth is passed to WAV writers
- test that mono and stereo writers reject invalid bit depth

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687ac86f8a308325b1ef778a1b10515d