### PR TITLE
Add audio filter tests

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,72 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+from music.core.filters import adsr, fade, cross_fade, reverb
+from music.core.filters.localization import localize
+
+
+def test_adsr_envelope_basic():
+    env = adsr(
+        envelope_duration=0.1,
+        attack_duration=10,
+        decay_duration=20,
+        sustain_level=-6,
+        release_duration=10,
+        transition="exp",
+        sample_rate=1000,
+    )
+    sustain_amp = 10 ** (-6 / 20)
+    assert len(env) == 100
+    assert env[0] < 1e-3
+    assert np.isclose(env[9], 1.0, atol=1e-6)
+    assert np.allclose(env[30:90], sustain_amp)
+    assert env[-1] < 1e-4
+
+
+def test_fade_and_cross_fade():
+    fade_out = fade(number_of_samples=5, fade_out=True, method="linear")
+    fade_in = fade(number_of_samples=5, fade_out=False, method="linear")
+    assert np.allclose(fade_out, np.linspace(1, 0, 5))
+    assert np.allclose(fade_in, np.linspace(0, 1, 5))
+
+    s1 = np.ones(441)
+    s2 = np.ones(441) * 2
+    mixed = cross_fade(s1.copy(), s2.copy(), duration=5, sample_rate=44100)
+    assert len(mixed) == 661
+    assert mixed[0] == 1.0
+    assert np.isclose(mixed[-1], 2.0, atol=1e-6)
+
+
+def test_reverb_minimal_operation():
+    np.random.seed(0)
+    ir = reverb(
+        duration=0.02,
+        first_phase_duration=0.01,
+        decay=-1,
+        noise_type="white",
+        sample_rate=100,
+    )
+    assert len(ir) == 2
+    assert ir[0] == 1.0
+
+    out = reverb(
+        duration=0.02,
+        first_phase_duration=0.01,
+        decay=-1,
+        noise_type="white",
+        sonic_vector=np.ones(5),
+        sample_rate=100,
+    )
+    assert out.shape == (6,)
+
+def test_localize_basic():
+    sv = np.ones(5)
+    out = localize(sonic_vector=sv, x=0.1, y=0.1, sample_rate=10)
+    assert out.shape[0] == 2
+    assert out.shape[1] >= 5
+    assert not np.allclose(out[0], out[1])
+

--- a/tests/test_notes_extra.py
+++ b/tests/test_notes_extra.py
@@ -1,0 +1,57 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+from music.core.synths.notes import (
+    note_with_doppler,
+    note_with_fm,
+    note_with_phase,
+    note_with_glissando,
+    note_with_glissando_vibrato,
+    note_with_two_vibratos_glissando,
+    note_with_vibrato,
+    note_with_two_vibratos,
+)
+from music.core.synths.envelopes import tremolo, tremolos
+
+
+def test_extra_note_functions_shapes():
+    params = dict(number_of_samples=10, sample_rate=100)
+    assert note_with_doppler(**params).shape == (2, 10)
+    assert note_with_fm(fm=0, max_fm_deviation=0, **params).shape == (10,)
+    assert note_with_phase(phase=0, **params).shape == (10,)
+    assert note_with_glissando(start_freq=220, end_freq=220, **params).shape == (10,)
+    assert note_with_glissando_vibrato(
+        start_freq=220,
+        end_freq=220,
+        vibrato_freq=0,
+        max_pitch_dev=0,
+        **params
+    ).shape == (10,)
+    assert note_with_two_vibratos_glissando(
+        start_freq=220,
+        end_freq=220,
+        vibrato_freq=0,
+        secondary_vibrato_freq=0,
+        max_pitch_dev=0,
+        **params
+    ).shape == (10,)
+    assert note_with_vibrato(vibrato_freq=0, max_pitch_dev=0, **params).shape == (10,)
+    assert note_with_two_vibratos(
+        vibrato_freq=0,
+        secondary_vibrato_freq=0,
+        nu1=0,
+        nu2=0,
+        **params
+    ).shape == (10,)
+    assert tremolo(number_of_samples=10, tremolo_freq=0, max_db_dev=0, sample_rate=100).shape == (10,)
+    assert tremolos(
+        number_of_samples=[[5, 5]],
+        tremolo_freqs=[[0, 0]],
+        max_db_devs=[[0, 0]],
+        sample_rate=100,
+    ).shape == (10,)
+


### PR DESCRIPTION
## Summary
- test adsr envelope behavior
- test fade and cross_fade utilities
- add minimal localize and reverb checks
- cover additional note generators

## Testing
- `pytest -q`
- `pytest -q --cov=music`

------
https://chatgpt.com/codex/tasks/task_e_687ac8808888832597c3012ef994f283