### PR TITLE
Refactor git cloning with subprocess

### DIFF
--- a/music/singing/bootstrap.py
+++ b/music/singing/bootstrap.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from .perform import sing
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -13,7 +14,14 @@ def get_engine(method="http"):
         repo_url = 'git@github.com:ttm/ecantorix.git'
     else:
         raise ValueError('method not understood')
-    os.system('git clone ' + repo_url + ' ' + ECANTORIXDIR)
+
+    if os.path.exists(ECANTORIXDIR):
+        return
+
+    try:
+        subprocess.run(['git', 'clone', repo_url, ECANTORIXDIR], check=True)
+    except Exception as exc:
+        raise RuntimeError(f'Failed to clone repository: {exc}') from exc
     return
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+import music.singing.bootstrap as bootstrap
+
+
+def test_get_engine_invokes_git_clone_when_missing():
+    with patch.object(bootstrap.os.path, 'exists', return_value=False):
+        with patch.object(bootstrap.subprocess, 'run') as mock_run:
+            bootstrap.get_engine(method='http')
+            mock_run.assert_called_once_with(
+                ['git', 'clone', 'https://github.com/ttm/ecantorix', bootstrap.ECANTORIXDIR],
+                check=True
+            )
+
+
+def test_get_engine_skips_when_dir_exists():
+    with patch.object(bootstrap.os.path, 'exists', return_value=True):
+        with patch.object(bootstrap.subprocess, 'run') as mock_run:
+            bootstrap.get_engine(method='http')
+            mock_run.assert_not_called()


### PR DESCRIPTION
## Summary
- refactor `get_engine` to use `subprocess.run`
- add safety check for existing `ECANTORIXDIR`
- raise `RuntimeError` if cloning fails
- test that git clone is invoked correctly and skipped when directory exists

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687ac971e29c83259345fe14549c1c54