### PR TITLE
Fix duplicate normalization step

### DIFF
--- a/music/core/functions.py
+++ b/music/core/functions.py
@@ -97,6 +97,5 @@ def normalize_stereo(sonic_vector, remove_bias=True, normalize_sep=False):
         else:
             amplitude = max(amplitude_ch_1, amplitude_ch_2)
             sv_copy = (sv_copy - sv_copy.min()) / amplitude
-            sv_copy = (sv_copy - sv_copy.min()) / amplitude
             sv_normalized = sv_copy * 2 - 1
     return sv_normalized


### PR DESCRIPTION
## Summary
- remove repeated scaling in stereo normalization

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687acb479b8883259f4211f9ab8133de