### PR TITLE
Replace prints with logging or warnings

### DIFF
--- a/music/core/filters/fade.py
+++ b/music/core/filters/fade.py
@@ -121,7 +121,7 @@ def cross_fade(sonic_vector_1, sonic_vector_2, duration=500, method='lin',
     """
     ns = int(duration * sample_rate / 1000)
     if len(sonic_vector_1.shape) != len(sonic_vector_2.shape):
-        print('enter s1 and s2 with the same shape')
+        raise ValueError('sonic_vector_1 and sonic_vector_2 must have the same shape')
     if len(sonic_vector_1.shape) == 2:
         s1_ = cross_fade(sonic_vector_1[0], sonic_vector_2[0], duration,
                          method, sample_rate)

--- a/music/core/filters/localization.py
+++ b/music/core/filters/localization.py
@@ -1,6 +1,7 @@
 """Stereo localization filters and related helpers."""
 
 import numpy as np
+import warnings
 from music.core.synths.notes import note, note_with_phase
 from music.utils import WAVEFORM_SINE
 
@@ -222,7 +223,7 @@ def localize2(sonic_vector=note(), theta=-70, x=.1, y=.01, zeta=0.215,
 
     """
     if method not in ("ifft", "brute"):
-        print("The only methods implemented are ifft and brute")
+        raise ValueError("The only methods implemented are ifft and brute")
     if not theta:
         theta_ = np.arctan2(-x, y)
     else:
@@ -296,7 +297,7 @@ def localize2(sonic_vector=note(), theta=-70, x=.1, y=.01, zeta=0.215,
                 normsr[i] *= iid
 
     elif method == "brute":
-        print("This can take a long time...")
+        warnings.warn("This can take a long time...")
         for i in range(ncoeffs):
             if i == 0:
                 continue

--- a/music/core/io.py
+++ b/music/core/io.py
@@ -1,6 +1,7 @@
 """Utilities for reading and writing WAV files."""
 
 import numpy as np
+import logging
 from scipy.io import wavfile
 from .functions import normalize_mono, normalize_stereo
 from .filters import adsr, adsr_stereo
@@ -24,10 +25,9 @@ def read_wav(filename: str):
         Values of the WAV file
     """
     s = wavfile.read(filename)
-    print(type(s[1] / 2 ** 15))
+    logging.debug(type(s[1] / 2 ** 15))
     if s[1].dtype != 'int16':
-        print('implement non 16bit samples!')
-        return np.array(None)
+        raise ValueError('non 16-bit samples are not supported')
     if len(s[1].shape) == 2:
         return np.array(s[1].transpose() / 2 ** 15)
     return s[1] / 2 ** 15

--- a/music/core/synths/noises.py
+++ b/music/core/synths/noises.py
@@ -67,10 +67,10 @@ def noise(noise_type="brown", duration=2, min_freq=15, max_freq=15000,
     elif isinstance(noise_type, Number):
         prog = noise_type
     else:
-        print("Set ntype to a number or one of the following strings:\
-                'white', 'pink', 'brown', 'blue', 'violet', 'black'.\
-                Check docstring for more information.")
-        return
+        raise ValueError(
+            "Set ntype to a number or one of the following strings: "
+            "'white', 'pink', 'brown', 'blue', 'violet', 'black'. "
+            "Check docstring for more information.")
 
     coeffs = np.zeros(length)
     coeffs[:length // 2] = np.exp(1j *

--- a/music/legacy/classes.py
+++ b/music/legacy/classes.py
@@ -1,6 +1,7 @@
 """Utility classes supporting the legacy synthesizer API."""
 
 import numpy as n
+import logging
 
 from music.legacy import tables
 from music.utils import horizontal_stack
@@ -171,7 +172,7 @@ class Being:
                                        self.seqsize]
                 else:
                     domain = n_.array(self.domain)
-                    print("Implemented OK?? TTM")
+                    logging.debug("Implemented OK?? TTM")
             else:
                 domain = self.domain
             # nel = self.perms[0].size  # should match self.seqsize ?

--- a/music/singing/perform.py
+++ b/music/singing/perform.py
@@ -3,6 +3,8 @@
 
 import os
 import re
+import warnings
+import logging
 from scipy.io import wavfile
 from music.core import normalize_mono
 
@@ -15,7 +17,7 @@ if not os.path.isdir(ECANTORIXCACHE):
                   ECANTORIXDIR)
         os.mkdir(ECANTORIXCACHE)
     except IOError:
-        print('install git if you want singing facilities')
+        warnings.warn('install git if you want singing facilities')
 
 
 # def sing(text="ba-na-nin-ha pra vo-cê",
@@ -106,4 +108,4 @@ converter = Notes()
 
 if __name__ == '__main__':
     narray = sing()
-    print("finished")
+    logging.info("finished")

--- a/music/structures/peals/plain_changes.py
+++ b/music/structures/peals/plain_changes.py
@@ -6,6 +6,7 @@ Reference:
 """
 
 import sympy
+import warnings
 
 
 class PlainChanges:
@@ -64,8 +65,9 @@ class PlainChanges:
         if nhunts > nelements:
             raise ValueError("There cannot be more hunts than elements")
         elif nhunts > nelements - 3:
-            print("peals are the same if there are", nhunts - (nelements - 3),
-                  "hunts less")
+            warnings.warn(
+                f"peals are the same if there are {nhunts - (nelements - 3)} "
+                "hunts less")
         hunts_dict = {}
         for hunt in range(nhunts):
             if hunt == nhunts - 1:

--- a/music/utils.py
+++ b/music/utils.py
@@ -1,6 +1,8 @@
 """Utility functions shared across the package."""
 
 import numpy as np
+import warnings
+import logging
 
 LAMBDA_TILDE = 1024 * 16
 WAVEFORM_SINE = np.sin(np.linspace(0, 2 * np.pi, LAMBDA_TILDE, endpoint=False))
@@ -413,8 +415,9 @@ def convert_to_stereo(sound_vector):
     elif sound_array.shape[0] > 2:
         # If the input vector has more than two channels, keep only the first
         # two (left and right) and sum the rest to both left and right channels
-        print('Keeping first two channels in left and right. '
-              'The rest will be added to both left and right.')
+        warnings.warn(
+            'Keeping first two channels in left and right. '
+            'The rest will be added to both left and right.')
         stereo_sound = np.array((sound_array[0], sound_array[1]))
         for channel in sound_array[2:]:
             stereo_sound += channel
@@ -476,8 +479,13 @@ def mix_with_offset(first_sonic_vector, second_sonic_vector,
 
     s = np.zeros(int(nst))
     s[:len(first_sonic_vector)] += first_sonic_vector
-    print('s.shape', 's1.shape', 's2.shape', 'ns', 'nst', s.shape,
-          first_sonic_vector.shape, second_sonic_vector.shape, ns, nst)
+    logging.debug(
+        's.shape %s s1.shape %s s2.shape %s ns %s nst %s',
+        s.shape,
+        first_sonic_vector.shape,
+        second_sonic_vector.shape,
+        ns,
+        nst)
     if ns >= 0:
         s[ns: ns + len(second_sonic_vector)] += second_sonic_vector
         # s[-len(s2):] += s2
@@ -528,11 +536,9 @@ def mix_with_offset_(*args):
     while i < len(args):
         a = args[i]  # new array
         if type(a) not in (np.ndarray, list):
-            print("Something odd happened,")
-            print("skipping a value that should have been\
-                  a sequence of numbers:", a)
-            i += 1
-            continue
+            raise ValueError(
+                "Skipping a value that should have been a sequence of numbers:" 
+                f" {a}")
         if len(args) > i + 1:
             offset = args[i + 1]  # potentialy duration
             if np.isscalar(offset):


### PR DESCRIPTION
## Summary
- replace misused print statements with errors or warnings
- update informational prints to use logging

## Testing
- `pytest -q` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687be14f69f0832598ab33bae878f797