### PR TITLE
Fix mutable defaults

### DIFF
--- a/music/core/filters/loud.py
+++ b/music/core/filters/loud.py
@@ -107,8 +107,8 @@ def loud(duration=2, trans_dev=10, alpha=1, to=True, method="exp",
         return e
 
 
-def louds(durations=[2, 4, 2], trans_devs=[5, -10, 20], alpha=[1, .5, 20],
-          method=["exp", "exp", "exp"], number_of_samples=0, sonic_vector=0,
+def louds(durations=(2, 4, 2), trans_devs=(5, -10, 20), alpha=(1, .5, 20),
+          method=("exp", "exp", "exp"), number_of_samples=0, sonic_vector=0,
           sample_rate=44100):
     """
     An envelope with linear or exponential transitions of amplitude.

--- a/music/core/filters/stretches.py
+++ b/music/core/filters/stretches.py
@@ -4,7 +4,7 @@ import numpy as np
 from music.utils import horizontal_stack
 
 
-def stretches(x, durations=[1, 4, 8, 12], sample_rate=44100):
+def stretches(x, durations=(1, 4, 8, 12), sample_rate=44100):
     """
     Makes a sequence of squeezes of the fragment in x.
 

--- a/music/core/synths/envelopes.py
+++ b/music/core/synths/envelopes.py
@@ -188,13 +188,13 @@ def tremolo(duration=2, tremolo_freq=2, max_db_dev=10, alpha=1,
         return t
 
 
-def tremolos(durations=[[3, 4, 5], [2, 3, 7, 4]],
-             tremolo_freqs=[[2, 6, 20], [5, 6.2, 21, 5]],
-             max_db_devs=[[10, 20, 1], [5, 7, 9, 2]],
-             alpha=[[1, 1, 1], [1, 1, 1, 9]],
-             waveform_tables=[[WAVEFORM_SINE, WAVEFORM_SINE, WAVEFORM_SINE],
-                              [WAVEFORM_TRIANGULAR, WAVEFORM_TRIANGULAR,
-                               WAVEFORM_TRIANGULAR, WAVEFORM_SINE]],
+def tremolos(durations=((3, 4, 5), (2, 3, 7, 4)),
+             tremolo_freqs=((2, 6, 20), (5, 6.2, 21, 5)),
+             max_db_devs=((10, 20, 1), (5, 7, 9, 2)),
+             alpha=((1, 1, 1), (1, 1, 1, 9)),
+             waveform_tables=((WAVEFORM_SINE, WAVEFORM_SINE, WAVEFORM_SINE),
+                              (WAVEFORM_TRIANGULAR, WAVEFORM_TRIANGULAR,
+                               WAVEFORM_TRIANGULAR, WAVEFORM_SINE)),
              number_of_samples=0, sonic_vector=0, sample_rate=44100):
     """
     An envelope with multiple tremolos.
@@ -252,9 +252,10 @@ def tremolos(durations=[[3, 4, 5], [2, 3, 7, 4]],
 
 
     """
-    for i in range(len(waveform_tables)):
-        for j in range(i):
-            waveform_tables[i][j] = np.array(waveform_tables[i][j])
+    waveform_tables = [
+        [np.array(wt) for wt in row]
+        for row in waveform_tables
+    ]
     t_ = []
     if number_of_samples:
         for i, ns in enumerate(number_of_samples):

--- a/music/core/synths/notes.py
+++ b/music/core/synths/notes.py
@@ -69,7 +69,7 @@ def note(freq=220, duration=2, waveform_table=WAVEFORM_TRIANGULAR,
 
 
 def note_with_doppler(freq=220, duration=2, waveform_table=WAVEFORM_TRIANGULAR,
-                      x=[-10, 10], y=[1, 1], stereo=True, zeta=0.215,
+                      x=(-10, 10), y=(1, 1), stereo=True, zeta=0.215,
                       air_temp=20, number_of_samples=0, sample_rate=44100):
     """
     A simple note with a transition of localization and resulting Doppler
@@ -502,27 +502,27 @@ def note_with_glissando_vibrato(start_freq=220, end_freq=440, duration=2,
 
 
 # FIXME: Unused param (`number_of_samples`)
-def note_with_vibrato_seq_localization(freqs=[220, 440, 330],
-                                       durations=[[2, 3], [2, 5, 3],
-                                                  [2, 5, 6, 1, .4],
-                                                  [4, 6, 1]],
-                                       vibratos_freqs=[[2, 6, 1],
-                                                       [.5, 15, 2, 6, 3]],
-                                       max_pitch_devs=[[2, 1, 5],
-                                                       [4, 3, 7, 10, 3]],
-                                       alpha=[[1, 1], [1, 1, 1],
-                                              [1, 1, 1, 1, 1], [1, 1, 1]],
-                                       x=[-10, 10, 5, 3], y=[1, 1, .1, .1],
-                                       method=['lin', 'exp', 'lin'],
-                                       waveform_tables=[
-                                           [WAVEFORM_TRIANGULAR,
-                                            WAVEFORM_TRIANGULAR],
-                                           [WAVEFORM_SINE,
+def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
+                                       durations=((2, 3), (2, 5, 3),
+                                                  (2, 5, 6, 1, .4),
+                                                  (4, 6, 1)),
+                                       vibratos_freqs=((2, 6, 1),
+                                                       (.5, 15, 2, 6, 3)),
+                                       max_pitch_devs=((2, 1, 5),
+                                                       (4, 3, 7, 10, 3)),
+                                       alpha=((1, 1), (1, 1, 1),
+                                              (1, 1, 1, 1, 1), (1, 1, 1)),
+                                       x=(-10, 10, 5, 3), y=(1, 1, .1, .1),
+                                       method=('lin', 'exp', 'lin'),
+                                       waveform_tables=(
+                                           (WAVEFORM_TRIANGULAR,
+                                            WAVEFORM_TRIANGULAR),
+                                           (WAVEFORM_SINE,
                                             WAVEFORM_TRIANGULAR,
-                                            WAVEFORM_SINE],
-                                           [WAVEFORM_SINE, WAVEFORM_SINE,
+                                            WAVEFORM_SINE),
+                                           (WAVEFORM_SINE, WAVEFORM_SINE,
                                             WAVEFORM_SINE, WAVEFORM_SINE,
-                                            WAVEFORM_SINE]],
+                                            WAVEFORM_SINE)),
                                        stereo=True, zeta=0.215, air_temp=20,
                                        number_of_samples=0, sample_rate=44100):
     """
@@ -891,24 +891,24 @@ def note_with_two_vibratos_glissando(start_freq=220, end_freq=440, duration=2,
     return s
 
 
-def note_with_vibratos_glissandos(freqs=[220, 440, 330],
-                                  durations=[[2, 3], [2, 5, 3],
-                                             [2, 5, 6, 1, .4]],
-                                  vibratos_freqs=[[2, 6, 1],
-                                                  [.5, 15, 2, 6, 3]],
-                                  vibratos_max_pitch_devs=[[2, 1, 5],
-                                                           [4, 3, 7, 10, 3]],
-                                  alpha=[[1, 1], [1, 1, 1], [1, 1, 1, 1, 1]],
-                                  waveform_tables=[[WAVEFORM_TRIANGULAR,
-                                                    WAVEFORM_TRIANGULAR],
-                                                   [WAVEFORM_SINE,
+def note_with_vibratos_glissandos(freqs=(220, 440, 330),
+                                  durations=((2, 3), (2, 5, 3),
+                                             (2, 5, 6, 1, .4)),
+                                  vibratos_freqs=((2, 6, 1),
+                                                  (.5, 15, 2, 6, 3)),
+                                  vibratos_max_pitch_devs=((2, 1, 5),
+                                                           (4, 3, 7, 10, 3)),
+                                  alpha=((1, 1), (1, 1, 1), (1, 1, 1, 1, 1)),
+                                  waveform_tables=((WAVEFORM_TRIANGULAR,
+                                                    WAVEFORM_TRIANGULAR),
+                                                   (WAVEFORM_SINE,
                                                     WAVEFORM_TRIANGULAR,
-                                                    WAVEFORM_SINE],
-                                                   [WAVEFORM_SINE,
+                                                    WAVEFORM_SINE),
+                                                   (WAVEFORM_SINE,
                                                     WAVEFORM_SINE,
                                                     WAVEFORM_SINE,
                                                     WAVEFORM_SINE,
-                                                    WAVEFORM_SINE]],
+                                                    WAVEFORM_SINE)),
                                   number_of_samples=0, sample_rate=44100):
     """
     A note with an arbitrary sequence of pitch transition and a meta-vibrato.
@@ -1214,7 +1214,7 @@ def note_with_two_vibratos(freq=220, duration=2, vibrato_freq=2,
     return s
 
 
-def trill(freqs=[440, 440 * 2 ** (2 / 12)], notes_per_second=17, duration=5,
+def trill(freqs=(440, 440 * 2 ** (2 / 12)), notes_per_second=17, duration=5,
           sample_rate=44100):
     """
     Makes a trill.

--- a/music/structures/peals/peals.py
+++ b/music/structures/peals/peals.py
@@ -10,7 +10,7 @@ from ..permutations import InterestingPermutations
 init()
 
 
-def print_peal(peal, hunts=[0, 1]):
+def print_peal(peal, hunts=(0, 1)):
     """
     Prints a peal with colored numbers. Hunts have also colored background.
 

--- a/music/utils.py
+++ b/music/utils.py
@@ -205,7 +205,7 @@ def midi_to_hz_interval(midi_interval: float) -> float:
 
 
 def pitch_to_freq(start_freq: float = 220.,
-                  semitones: list = [0, 7, 7, 4, 7, 0]) -> list:
+                  semitones: tuple = (0, 7, 7, 4, 7, 0)) -> list:
     """Generates a list of frequencies based on a list of semitones and a
     starting frequency.
 
@@ -278,7 +278,7 @@ def mix(first_sonic_vector: np.ndarray,
 
 
 def mix_stereo(first_sonic_vector: np.ndarray,
-               second_sonic_vector: np.ndarray = [],
+               second_sonic_vector: np.ndarray = (),
                end: bool = False) -> np.ndarray:
     """Mixes two stereo sonic vectors.
 
@@ -341,7 +341,7 @@ def mix_stereo(first_sonic_vector: np.ndarray,
     return l1_ + l2_
 
 
-def resolve_stereo(afunction, argdict, stereo_vars=['sonic_vector']):
+def resolve_stereo(afunction, argdict, stereo_vars=('sonic_vector',)):
     """Resolve stereo arguments for a function.
 
     Parameters
@@ -553,8 +553,8 @@ def mix_with_offset_(*args):
     return s
 
 
-def pan_transitions(p=[(1, 1), (1, 0), (0, 1), (1, 1)], d=[2, 2, 2],
-                    method=['lin', 'circ', 'exp'], sample_rate=44100,
+def pan_transitions(p=((1, 1), (1, 0), (0, 1), (1, 1)), d=(2, 2, 2),
+                    method=('lin', 'circ', 'exp'), sample_rate=44100,
                     sonic_vector=None):
     """Applies pan transitions to a sonic vector.
 
@@ -761,7 +761,7 @@ def profile(adict):
     #         print('unrecognized type, implement dealing with it')
 
 
-def rhythm_to_durations(durations=[4, 2, 2, 4, 1, 1, 1, 1, 2, 2, 4],
+def rhythm_to_durations(durations=(4, 2, 2, 4, 1, 1, 1, 1, 2, 2, 4),
                         freqs=None, duration=.25, bpm=None,
                         total_duration=None):
     """Returns durations from rhythmic patterns.


### PR DESCRIPTION
## Summary
- use tuples instead of lists for default arguments
- adjust tremolos to avoid mutating arguments
- keep behaviour with passing arguments

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687be7efba7083258e88b4e843a39619