### PR TITLE
Refactor eCantorix bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Inside [the examples folder](https://github.com/ttm/music/tree/master/examples) 
 * [thirty_notes](https://github.com/ttm/music/tree/master/examples/thirty_notes.py) and [thirty_numpy_notes](https://github.com/ttm/music/tree/master/examples/thirty_numpy_notes.py) generate a sequence of sounds by using a synth class (in this case the class [`Being`](https://github.com/ttm/music/tree/master/music/legacy/classes.py)).
 * [campanology](https://github.com/ttm/music/tree/master/examples/campanology.py) and [geometric_music](https://github.com/ttm/music/tree/master/examples/geometric_music.py) both use `Being` as their synth, but this time with permutations.
 * [isynth](https://github.com/ttm/music/tree/master/examples/isynth.py) also uses a synth class, but of a different kind, [`IteratorSynth`](https://github.com/ttm/music/tree/master/music/legacy/classes.py), that iterates through arbitrary lists of variables.
+* The `music.singing` module provides basic text-to-speech utilities. Run `music.singing.setup_engine()` once to clone the eCantorix engine before using these features.
 
 ## Package structure
 

--- a/music/__init__.py
+++ b/music/__init__.py
@@ -68,7 +68,7 @@ from .structures import (
     print_peal,
     transpose_permutation
 )
-from .singing import get_engine, make_test_song
+from .singing import get_engine, make_test_song, setup_engine
 from .legacy import Being, CanonicalSynth, IteratorSynth
 
 __all__ = [
@@ -88,6 +88,7 @@ __all__ = [
     'gaussian_noise',
     'GenericPeal',
     'get_engine',
+    'setup_engine',
     'horizontal_stack',
     'hz_to_midi',
     'iir',

--- a/music/singing/__init__.py
+++ b/music/singing/__init__.py
@@ -1,8 +1,9 @@
 """Simple utilities for text-to-speech demo generation."""
 
-from .bootstrap import get_engine, make_test_song
+from .bootstrap import get_engine, make_test_song, setup_engine
 
 __all__ = [
     'get_engine',
+    'setup_engine',
     'make_test_song'
 ]

--- a/music/singing/bootstrap.py
+++ b/music/singing/bootstrap.py
@@ -8,8 +8,20 @@ here = os.path.abspath(os.path.dirname(__file__))
 ECANTORIXDIR = here + '/ecantorix'
 
 
-def get_engine(method="http"):
-    """pull ecantorix repo for local usage"""
+def get_engine():
+    """Return path to the local eCantorix engine."""
+    if not os.path.exists(ECANTORIXDIR):
+        raise RuntimeError(
+            "eCantorix engine not found. Run 'setup_engine()' to install it."
+        )
+    return ECANTORIXDIR
+
+
+def setup_engine(method="http"):
+    """Clone the eCantorix repository for local usage."""
+    if os.path.exists(ECANTORIXDIR):
+        return
+
     if method == "http":
         repo_url = 'https://github.com/ttm/ecantorix'
     elif method == "ssh":
@@ -17,14 +29,11 @@ def get_engine(method="http"):
     else:
         raise ValueError('method not understood')
 
-    if os.path.exists(ECANTORIXDIR):
-        return
-
     try:
         subprocess.run(['git', 'clone', repo_url, ECANTORIXDIR], check=True)
     except Exception as exc:
         raise RuntimeError(f'Failed to clone repository: {exc}') from exc
-    return
+    return ECANTORIXDIR
 
 
 def make_test_song():

--- a/music/singing/perform.py
+++ b/music/singing/perform.py
@@ -11,13 +11,6 @@ from music.core import normalize_mono
 here = os.path.abspath(os.path.dirname(__file__))
 ECANTORIXDIR = here + '/ecantorix'
 ECANTORIXCACHE = ECANTORIXDIR + '/cache'
-if not os.path.isdir(ECANTORIXCACHE):
-    try:
-        os.system('git clone https://github.com/divVerent/ecantorix ' +
-                  ECANTORIXDIR)
-        os.mkdir(ECANTORIXCACHE)
-    except IOError:
-        warnings.warn('install git if you want singing facilities')
 
 
 # def sing(text="ba-na-nin-ha pra vo-cê",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -8,18 +8,18 @@ sys.path.insert(0, str(HERE))
 import music.singing.bootstrap as bootstrap
 
 
-def test_get_engine_invokes_git_clone_when_missing():
+def test_setup_engine_invokes_git_clone_when_missing():
     with patch.object(bootstrap.os.path, 'exists', return_value=False):
         with patch.object(bootstrap.subprocess, 'run') as mock_run:
-            bootstrap.get_engine(method='http')
+            bootstrap.setup_engine(method='http')
             mock_run.assert_called_once_with(
                 ['git', 'clone', 'https://github.com/ttm/ecantorix', bootstrap.ECANTORIXDIR],
                 check=True
             )
 
 
-def test_get_engine_skips_when_dir_exists():
+def test_setup_engine_skips_when_dir_exists():
     with patch.object(bootstrap.os.path, 'exists', return_value=True):
         with patch.object(bootstrap.subprocess, 'run') as mock_run:
-            bootstrap.get_engine(method='http')
+            bootstrap.setup_engine(method='http')
             mock_run.assert_not_called()


### PR DESCRIPTION
## Summary
- add explicit `setup_engine()` to clone eCantorix
- avoid cloning at import time
- adjust exports and update README
- update bootstrap tests

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687bec0076388325999179a74147f1be