### PR TITLE
Fix log2 warnings

### DIFF
--- a/music/core/synths/noises.py
+++ b/music/core/synths/noises.py
@@ -72,7 +72,7 @@ def noise(noise_type="brown", duration=2, min_freq=15, max_freq=15000,
             "'white', 'pink', 'brown', 'blue', 'violet', 'black'. "
             "Check docstring for more information.")
 
-    coeffs = np.zeros(length)
+    coeffs = np.zeros(length, dtype=complex)
     coeffs[:length // 2] = np.exp(1j *
                                   np.random.uniform(0, 2 * np.pi, length // 2))
     if length % 2 == 0:
@@ -80,14 +80,16 @@ def noise(noise_type="brown", duration=2, min_freq=15, max_freq=15000,
 
     freq_res = sample_rate / length
     first_coeff = int(np.floor(min_freq / freq_res))
+    first_coeff = max(1, first_coeff)
     last_coeff = int(np.floor(max_freq / freq_res))
     coeffs[:first_coeff] = 0
     coeffs[last_coeff:] = 0
 
     factor = 10. ** (prog / 20.)
     freq_i = np.arange(coeffs.shape[0]) * freq_res
-    attenuation_factors = factor ** (np.log2(freq_i[first_coeff:last_coeff] /
-                                             min_freq))
+    denom = max(min_freq, freq_res)
+    freqs = np.clip(freq_i[first_coeff:last_coeff], freq_res, None)
+    attenuation_factors = factor ** (np.log2(freqs / denom))
     coeffs[first_coeff:last_coeff] *= attenuation_factors
 
     if length % 2 == 0:

--- a/music/utils.py
+++ b/music/utils.py
@@ -146,7 +146,8 @@ def hz_to_midi(hertz_value: float) -> np.float64:
     >>> hz_to_midi(880)
     81.0
     """
-    return 69 + 12 * np.log2(hertz_value / 440)
+    safe_hz = np.clip(hertz_value, np.finfo(float).eps, None)
+    return 69 + 12 * np.log2(safe_hz / 440)
 
 
 def midi_to_hz(midi_value: float) -> float:

--- a/tests/test_synths.py
+++ b/tests/test_synths.py
@@ -1,6 +1,8 @@
 import numpy as np
 import sys
 from pathlib import Path
+import pytest
+import warnings
 
 HERE = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(HERE))
@@ -45,6 +47,12 @@ def test_noise_and_silence_generation():
     gauss = music.gaussian_noise(duration=1)
     assert len(gauss) == 44100
     assert gauss.max() <= 1 and gauss.min() >= -1
+
+
+def test_noise_no_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        music.noise('white', duration=0.005)
 
 
 def test_note_with_doppler_stereo_shape():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import importlib.util
 from pathlib import Path
 import numpy as np
+import pytest
+import warnings
 
 HERE = Path(__file__).resolve().parents[1]
 
@@ -70,3 +72,9 @@ def test_mix2_offset_and_end():
 
     out_offset = utils.mix2([a, b], offset=[0, 1], sample_rate=1)
     assert np.allclose(out_offset, np.array([1, 2, 1, 1]))
+
+
+def test_hz_to_midi_no_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        utils.hz_to_midi(np.array([0.0, 440.0]))


### PR DESCRIPTION
## Summary
- clamp frequencies in hz_to_midi
- avoid zero bins for noise log2 attenuation
- check no warnings are emitted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfb8ec3b88325863d7edd9af340a7