### PR TITLE
Add dev extras and testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ This install method is especially useful when reloading the modified module in s
 
 Every dependency is installed by default by `pip`, but you can take a look at [requirements.txt](https://github.com/ttm/music/blob/master/requirements.txt).
 
+### Testing
+
+The packages required to run the test suite are available via the `dev`
+extras defined in `pyproject.toml`.  Install them with:
+
+```console
+pip install -e '.[dev]'
+```
+
+You can then run the tests using `pytest`:
+
+```console
+pytest
+```
+
 ## Examples
 
 Inside [the examples folder](https://github.com/ttm/music/tree/master/examples) you can find some scripts that use the main features of Music.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     'sympy >= 1.12',
     'termcolor >= 2.4.0',
 ]
+optional-dependencies = { dev = ['pytest >= 8.2'] }
 classifiers = [
     'Programming Language :: Python :: 3',
     'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
## Summary
- document how to install testing requirements
- add `dev` extras group in `pyproject.toml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c091e8ff08325a76c9117e95b0789