### PR TITLE
Improve singing error handling

### DIFF
--- a/music/singing/perform.py
+++ b/music/singing/perform.py
@@ -5,6 +5,7 @@ import os
 import re
 import warnings
 import logging
+import subprocess
 from scipy.io import wavfile
 from music.core import normalize_mono
 
@@ -38,9 +39,18 @@ def sing(text="Mar-ry had a litt-le lamb",
     with open(ECANTORIXCACHE + '/achant.conf', 'w') as f:
         f.write(conf_text)
     # write conf file
-    os.system('cp {}/Makefile {}/Makefile'.format(ECANTORIXDIR,
-                                                  ECANTORIXCACHE))
-    os.system('make -C {}'.format(ECANTORIXCACHE))
+    try:
+        subprocess.run(
+            [
+                'cp',
+                f'{ECANTORIXDIR}/Makefile',
+                f'{ECANTORIXCACHE}/Makefile'
+            ],
+            check=True,
+        )
+        subprocess.run(['make', '-C', ECANTORIXCACHE], check=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f'Failed to build singing cache: {exc}') from exc
     wread = wavfile.read(ECANTORIXCACHE + '/achant.wav')
     assert wread[0] == 44100
     return normalize_mono(wread[1])

--- a/tests/test_perform_failures.py
+++ b/tests/test_perform_failures.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch, mock_open
+import subprocess
+import pytest
+
+HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(HERE))
+
+import music.singing.perform as perform
+
+
+def test_sing_raises_when_copy_fails():
+    with patch.object(perform, 'write_abc'), \
+         patch.object(perform.subprocess, 'run', side_effect=subprocess.CalledProcessError(1, ['cp'])), \
+         patch.object(perform.wavfile, 'read'), \
+         patch('builtins.open', mock_open()):
+        with pytest.raises(RuntimeError):
+            perform.sing()
+
+
+def test_sing_raises_when_make_fails():
+    def side_effect(args, check):
+        if args[0] == 'cp':
+            return None
+        raise subprocess.CalledProcessError(1, args)
+
+    with patch.object(perform, 'write_abc'), \
+         patch.object(perform.subprocess, 'run', side_effect=side_effect), \
+         patch.object(perform.wavfile, 'read'), \
+         patch('builtins.open', mock_open()):
+        with pytest.raises(RuntimeError):
+            perform.sing()


### PR DESCRIPTION
## Summary
- swap `os.system` calls for `subprocess.run` in `music.singing.perform`
- raise `RuntimeError` on failed build steps
- add tests covering copy and make failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0b7566d08325ba7ef4f890fa3774