### PR TITLE
Add singing demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Inside [the examples folder](https://github.com/ttm/music/tree/master/examples) 
 * [thirty_notes](https://github.com/ttm/music/tree/master/examples/thirty_notes.py) and [thirty_numpy_notes](https://github.com/ttm/music/tree/master/examples/thirty_numpy_notes.py) generate a sequence of sounds by using a synth class (in this case the class [`Being`](https://github.com/ttm/music/tree/master/music/legacy/classes.py)).
 * [campanology](https://github.com/ttm/music/tree/master/examples/campanology.py) and [geometric_music](https://github.com/ttm/music/tree/master/examples/geometric_music.py) both use `Being` as their synth, but this time with permutations.
 * [isynth](https://github.com/ttm/music/tree/master/examples/isynth.py) also uses a synth class, but of a different kind, [`IteratorSynth`](https://github.com/ttm/music/tree/master/music/legacy/classes.py), that iterates through arbitrary lists of variables.
+* [singing_demo](https://github.com/ttm/music/tree/master/examples/singing_demo.py): demonstrates `music.singing.setup_engine()` and `music.singing.make_test_song()` to render a short sung phrase.
 * The `music.singing` module provides basic text-to-speech utilities. Run `music.singing.setup_engine()` once to clone the eCantorix engine before using these features.
 
 ## Package structure

--- a/examples/singing_demo.py
+++ b/examples/singing_demo.py
@@ -1,0 +1,9 @@
+"""Synthesize a short sung phrase using the singing utilities."""
+
+import music
+
+# Clone eCantorix engine if not already installed
+music.singing.setup_engine()
+
+# Render a short sung phrase inside the local cache folder
+music.singing.make_test_song()


### PR DESCRIPTION
## Summary
- add `examples/singing_demo.py` showcasing the singing utilities
- mention this new script in the README examples section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687df5174f208325a1107f37798ef0e7