### PR TITLE
Add play_audio utility

### DIFF
--- a/music/__init__.py
+++ b/music/__init__.py
@@ -57,6 +57,7 @@ from .core import (
     trill,
     write_wav_mono,
     write_wav_stereo,
+    play_audio,
 )
 from .tables import PrimaryTables
 from .structures import (
@@ -141,5 +142,6 @@ __all__ = [
     'trill',
     'write_wav_mono',
     'write_wav_stereo',
+    'play_audio',
     'Sequencer'
 ]

--- a/music/core/__init__.py
+++ b/music/core/__init__.py
@@ -36,7 +36,7 @@ from .filters import (
     stretches
 )
 from .functions import normalize_mono, normalize_stereo
-from .io import read_wav, write_wav_mono, write_wav_stereo
+from .io import read_wav, write_wav_mono, write_wav_stereo, play_audio
 from .synths import (
     am,
     gaussian_noise,
@@ -112,5 +112,6 @@ __all__ = [
     'tremolos',
     'trill',
     'write_wav_mono',
-    'write_wav_stereo'
+    'write_wav_stereo',
+    'play_audio'
 ]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sys
 from pathlib import Path
+from unittest.mock import patch
 import pytest
 from scipy.io import wavfile
 
@@ -34,3 +35,14 @@ def test_read_wav_32bit(tmp_path):
     wavfile.write(path, 8000, data)
     out = music.read_wav(str(path))
     assert np.allclose(out, data.astype(np.float64) / (2 ** 31))
+
+
+def test_play_audio_invocation():
+    import types
+    from unittest.mock import MagicMock
+
+    sd = types.SimpleNamespace(play=MagicMock(), wait=MagicMock())
+    with patch.dict(sys.modules, {"sounddevice": sd}):
+        music.play_audio(np.zeros(4), sample_rate=8000)
+    sd.play.assert_called_once()
+    sd.wait.assert_called_once()


### PR DESCRIPTION
## Summary
- add `play_audio` helper for on-the-fly audio playback
- expose `play_audio` from the core package
- test playback invocation with a mocked sounddevice module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7e2fe43083259eebf15be1db464e