### PR TITLE
Add binaural beats example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Inside [the examples folder](https://github.com/ttm/music/tree/master/examples) 
 * [campanology](https://github.com/ttm/music/tree/master/examples/campanology.py) and [geometric_music](https://github.com/ttm/music/tree/master/examples/geometric_music.py) both use `Being` as their synth, but this time with permutations.
 * [isynth](https://github.com/ttm/music/tree/master/examples/isynth.py) also uses a synth class, but of a different kind, [`IteratorSynth`](https://github.com/ttm/music/tree/master/music/legacy/classes.py), that iterates through arbitrary lists of variables.
 * [singing_demo](https://github.com/ttm/music/tree/master/examples/singing_demo.py): demonstrates `music.singing.setup_engine()` and `music.singing.make_test_song()` to render a short sung phrase.
+* [binaural_beats](https://github.com/ttm/music/tree/master/examples/binaural_beats.py): generates binaural beats using two pure tones with tremolo for relaxation or focus.
 * The `music.singing` module provides basic text-to-speech utilities. Run `music.singing.setup_engine()` once to clone the eCantorix engine before using these features.
 
 ## Package structure

--- a/examples/binaural_beats.py
+++ b/examples/binaural_beats.py
@@ -1,0 +1,42 @@
+"""Generate a binaural beat using Music's synthesis primitives.
+
+This script creates two sine waves with a small frequency difference and
+applies a gentle tremolo to each channel. Listening to the resulting
+stereo file can help create a calm environment for relaxation or focus.
+"""
+
+import numpy as np
+import music
+
+BASE_FREQ = 440.0  # central frequency in Hz
+BEAT_FREQ = 4.0    # difference between left and right in Hz
+DURATION = 10.0    # seconds
+TREMOLO_FREQ = 0.5  # Hz, slow amplitude modulation
+
+left = music.note_with_phase(
+    freq=BASE_FREQ - BEAT_FREQ / 2,
+    duration=DURATION,
+    waveform_table=music.tables.PrimaryTables().sine,
+)
+right = music.note_with_phase(
+    freq=BASE_FREQ + BEAT_FREQ / 2,
+    duration=DURATION,
+    waveform_table=music.tables.PrimaryTables().sine,
+)
+
+left = music.tremolo(
+    duration=DURATION,
+    tremolo_freq=TREMOLO_FREQ,
+    max_db_dev=3,
+    sonic_vector=left,
+)
+right = music.tremolo(
+    duration=DURATION,
+    tremolo_freq=TREMOLO_FREQ,
+    max_db_dev=3,
+    sonic_vector=right,
+)
+
+stereo = np.vstack((left, right))
+
+music.write_wav_stereo(stereo, "binaural_beats.wav")


### PR DESCRIPTION
## Summary
- add example demonstrating binaural beats with `note_with_phase` and `tremolo`
- document the new example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8333ac788325a1ecd374f1ad06da