### PR TITLE
Publish the API reference, and fix the docstrings that broke it

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install the package and its docs extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[docs]'
+
+      # -W turns Sphinx warnings into errors: a malformed docstring fails the
+      # build rather than quietly rendering wrong.
+      - name: Build
+        run: sphinx-build -b html -W --keep-going docs docs/_build/html
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ musicPacDir/
 htmlcov/
 .ruff_cache/
 build/
+docs/_build/
+docs/generated/

--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -306,16 +306,58 @@ Ordered by return on effort. Phase 1 is roughly a day and removes every "Terribl
 18. **Rework `setup_engine()`** to clone into a user cache dir (`platformdirs.user_cache_dir`),
     never `site-packages`; document the `git`/`make`/`perl`/`espeak` system dependencies and
     check for them with a clear error.
+19. **Convert the Google-style docstrings in `structures/` and `legacy/` to numpydoc.**
+    The package documents itself in two incompatible styles: 56 `Attributes:` / `Parameters:`
+    / `Returns:` / `Methods:` sections across seven files use Google style, while everything
+    else uses numpydoc. Publishing the API reference papered over this by enabling
+    `sphinx.ext.napoleon` alongside `numpydoc` — each extension renders the style it handles
+    best — but that is a workaround, not a fix. See the box below.
 
 ### Phase 5 — Surface the strengths
 
-19. **Publish the API docs.** Sphinx + `numpydoc` + `autodoc` on GitHub Pages. The docstrings
+20. **Publish the API docs.** Sphinx + `numpydoc` + `autodoc` on GitHub Pages. The docstrings
     are already exceptional; rendering them costs an afternoon and is the single biggest
-    increase in *perceived* quality available here.
-20. **Mark the README Roadmap as aspirational**, fix the trailing `:::`, and correct the
+    increase in *perceived* quality available here. *(Done — see below.)*
+21. **Mark the README Roadmap as aspirational**, fix the trailing `:::`, and correct the
     `noisy.py` docstring (it says "pentatonic scale"; it writes noises).
-21. **Add `CONTRIBUTING.md`**, a `legacy/` deprecation note, and backfill the changelog.
-22. **Delete stale `dist/` artifacts.**
+22. **Add `CONTRIBUTING.md`**, a `legacy/` deprecation note, and backfill the changelog.
+23. **Delete stale `dist/` artifacts.**
+
+---
+
+## Tracked follow-up: one docstring style
+
+**The package documents itself in two incompatible styles.** Most of it is numpydoc —
+`Parameters` / `Returns` / `See Also` / `Examples` / `Notes` / `References` under dashed
+underlines, with the equation and the MASS citation. But `music.structures` and
+`music.legacy` use Google style — `Attributes:`, `Parameters:`, `Returns:`, `Methods:` with
+a trailing colon — across **56 sections in seven files**:
+
+```
+music/structures/permutations.py        music/legacy/classes.py
+music/structures/peals/plain_changes.py music/legacy/tables.py
+music/structures/peals/peals.py         music/legacy/IteratorSynth.py
+music/structures/peals/base.py
+```
+
+numpydoc cannot parse Google style, so those entries rendered as mangled definition lists
+and block quotes. Publishing the API reference resolved that by enabling
+`sphinx.ext.napoleon` ahead of `numpydoc` with `napoleon_numpy_docstring = False`, so each
+extension handles the style it renders best. That cleared every `structures/` and `peals/`
+warning at once.
+
+**That is a workaround, not a fix.** It leaves the project with two documentation dialects,
+a second Sphinx extension carried purely for the older one, and a trap for anyone adding a
+docstring — there is no single correct style to copy. Converting the 56 sections to numpydoc
+would remove the `napoleon` dependency and the ambiguity together.
+
+It is deliberately not bundled with the docs work: it touches seven files, is mechanical but
+not automatic, and would have buried the four genuinely broken docstrings that publishing
+uncovered. Doing it separately keeps both diffs reviewable.
+
+Two things make it safer than it looks. `sphinx-build -W` now fails CI on a malformed
+docstring, so a botched conversion cannot land quietly. And the conversion can proceed one
+file at a time, dropping `napoleon` only once the last Google-style section is gone.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ deliberate, both are tracked, and neither should reach a release unreviewed.
   proportionally. Zero-length stages no longer divide by zero or stretch the
   envelope, and single-sample transitions no longer leak NaN.
 - `requires-python` corrected from `>=3.0` to `>=3.10`.
+- Docstring markup that broke the API reference. `localize`, `localize2`,
+  `mix_with_offset` and `mix_with_offset_` failed to render at all: the first
+  two had a `# FIXME: hrtf?` comment inside a `See Also` section and a
+  reference to an `hrtf` function that does not exist, the other two pointed
+  at `(.functions).mix2`, which is not a resolvable target. A further dozen
+  docstrings had malformed reStructuredText -- bullet continuations indented
+  under nothing, pseudo-code blocks without a literal marker, `|d|` read as a
+  substitution reference, `J_` as a link target, an unindented citation
+  continuation in `iir`, and a doctest continuation line missing its `...`.
 - Passing a tuple or an ndarray subclass as `sonic_vector` was silently
   ignored by `adsr`, `fade`, `loud`, `louds`, `tremolo`, `tremolos`, `am`,
   `reverb` and `adsr_stereo`: they detected a supplied vector with
@@ -75,6 +84,10 @@ deliberate, both are tracked, and neither should reach a release unreviewed.
   [-1, 1]), and removed a stray duplicate entry from the Returns section.
 
 ### Added
+- Sphinx documentation, published to GitHub Pages from `master`. The
+  reference groups all 69 exports by role rather than alphabetically, and CI
+  builds it with `-W`, so a malformed docstring fails rather than rendering
+  wrong. Fixing the docstrings this surfaced is listed under Fixed below.
 - `tests/test_fidelity.py`, checking that the synthesized *samples* match the
   equations the docstrings cite, not merely that they have the right shape:
   `note` and `note_with_vibrato` against their closed forms sample for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ deliberate, both are tracked, and neither should reach a release unreviewed.
   reference groups all 69 exports by role rather than alphabetically, and CI
   builds it with `-W`, so a malformed docstring fails rather than rendering
   wrong. Fixing the docstrings this surfaced is listed under Fixed below.
+  `sphinx.ext.napoleon` is enabled alongside `numpydoc` because
+  `music.structures` and `music.legacy` document themselves in Google style —
+  56 sections across seven files. That is a workaround; converting them to
+  numpydoc would let napoleon be dropped, and is tracked in `ASSESSMENT.md`
+  under "Tracked follow-up: one docstring style".
 - `tests/test_fidelity.py`, checking that the synthesized *samples* match the
   equations the docstrings cite, not merely that they have the right shape:
   `note` and `note_with_vibrato` against their closed forms sample for

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ pip install -e '.[dev]'
 mypy music
 ```
 
+### Documentation
+
+The API reference is published at
+[ttm.github.io/music](https://ttm.github.io/music/). To build it locally:
+
+```console
+pip install -e '.[docs]'
+sphinx-build -b html -W docs docs/_build/html
+```
+
+`-W` turns Sphinx warnings into errors, which is how CI builds it: a malformed
+docstring fails the build rather than quietly rendering wrong.
+
 ### Linting
 
 The code is checked with [ruff](https://docs.astral.sh/ruff/) at PEP 8's 79
@@ -134,7 +147,7 @@ music.core.io.write_wav_mono(music_)
 
 The code follows [PEP 8 conventions](https://peps.python.org/pep-0008/).
 
-For a better understanding of each function, the math behind it and see examples of their use, you can read their docstring.
+For a better understanding of each function, the math behind it and see examples of their use, you can read their docstring — or the rendered [API reference](https://ttm.github.io/music/api.html).
 
 ## Further information
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ music.core.io.write_wav_mono(music_)
 
 ## Coding conventions
 
-The code follows [PEP 8 conventions](https://peps.python.org/pep-0008/).
+The code follows [PEP 8 conventions](https://peps.python.org/pep-0008/), checked by `ruff` at 79 columns.
+
+Docstrings should be written in [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) style. Note that `music.structures` and `music.legacy` currently use Google style instead — converting them is a tracked follow-up, so please don't copy that pattern into new code.
 
 For a better understanding of each function, the math behind it and see examples of their use, you can read their docstring — or the rendered [API reference](https://ttm.github.io/music/api.html).
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,199 @@
+API reference
+=============
+
+Every name below is re-exported from the top level: ``music.note(...)`` works
+regardless of which submodule defines it.
+
+.. currentmodule:: music
+
+Synthesis
+---------
+
+Notes
+~~~~~
+
+Each returns a numpy array of PCM samples. ``note`` is the plain wavetable
+lookup; the rest layer vibrato, pitch transitions, frequency modulation and
+movement onto it.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   note
+   note_with_phase
+   note_with_vibrato
+   note_with_two_vibratos
+   note_with_glissando
+   note_with_glissando_vibrato
+   note_with_two_vibratos_glissando
+   note_with_vibratos_glissandos
+   note_with_vibrato_seq_localization
+   note_with_fm
+   note_with_doppler
+   trill
+
+Envelopes and noise
+~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   am
+   tremolo
+   tremolos
+   noise
+   gaussian_noise
+   silence
+
+Filters
+-------
+
+Amplitude
+~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   adsr
+   adsr_stereo
+   adsr_vibrato
+   fade
+   cross_fade
+   loud
+   louds
+
+Spectral and spatial
+~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   fir
+   iir
+   reverb
+   localize
+   localize2
+   stretches
+
+Input and output
+----------------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   read_wav
+   write_wav_mono
+   write_wav_stereo
+   play_audio
+   normalize_mono
+   normalize_stereo
+
+Sequencing
+----------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Sequencer
+
+Musical structures
+------------------
+
+Permutations, algebraic groups and change-ringing peals.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   InterestingPermutations
+   transpose_permutation
+   dist
+   GenericPeal
+   Peals
+   PlainChanges
+   print_peal
+
+Utilities
+---------
+
+Conversions
+~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   hz_to_midi
+   midi_to_hz
+   midi_to_hz_interval
+   pitch_to_freq
+   db_to_amp
+   amp_to_db
+   rhythm_to_durations
+
+Combining sonic vectors
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   horizontal_stack
+   mix
+   mix2
+   mix_stereo
+   mix_with_offset
+   mix_with_offset_
+   convert_to_stereo
+   resolve_stereo
+   pan_transitions
+   profile
+
+Wavetables
+----------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   PrimaryTables
+
+The module-level constants ``WAVEFORM_SINE``, ``WAVEFORM_TRIANGULAR``,
+``WAVEFORM_SQUARE`` and ``WAVEFORM_SAWTOOTH`` in :mod:`music.utils` are the
+lookup tables used by default throughout the package.
+
+Singing
+-------
+
+Text-to-speech built on the external `eCantorix
+<https://github.com/ttm/ecantorix>`_ engine. Run :func:`setup_engine` once to
+clone it; it also needs ``git``, ``make``, ``perl`` and ``espeak`` on the
+system.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   setup_engine
+   get_engine
+   make_test_song
+
+Legacy
+------
+
+Synthesizer classes kept for backwards compatibility, and as material for
+making more music.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Being
+   CanonicalSynth
+   IteratorSynth

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,69 @@
+"""Sphinx configuration for the music package documentation."""
+
+from importlib.metadata import version as _version
+
+project = "music"
+author = "Renato Fabbri, Jacopo Donati"
+copyright = "2024-2026, Renato Fabbri"
+release = _version("music")
+version = ".".join(release.split(".")[:2])
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.mathjax",
+    # napoleon must be listed before numpydoc: it converts the Google-style
+    # docstrings in music.structures and music.legacy, and with
+    # napoleon_numpy_docstring off it leaves the numpydoc-style ones for
+    # numpydoc to render.
+    "sphinx.ext.napoleon",
+    "numpydoc",
+]
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+
+# The docstrings in this package are numpydoc-style, with Parameters,
+# Returns, See Also, Examples, Notes and References sections.
+numpydoc_show_class_members = False
+numpydoc_class_members_toctree = False
+numpydoc_xref_param_type = True
+
+autosummary_generate = True
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+}
+autodoc_typehints = "description"
+autodoc_member_order = "bysource"
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+}
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "furo"
+html_title = f"music {release}"
+html_theme_options = {
+    "source_repository": "https://github.com/ttm/music/",
+    "source_branch": "master",
+    "source_directory": "docs/",
+    "light_css_variables": {
+        "color-brand-primary": "#0e6b76",
+        "color-brand-content": "#0e6b76",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#4fbecb",
+        "color-brand-content": "#4fbecb",
+    },
+}
+
+# Some docstring Examples reference names that are illustrative rather than
+# importable; do not let those become nitpick failures.
+nitpicky = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,11 @@ extensions = [
     # docstrings in music.structures and music.legacy, and with
     # napoleon_numpy_docstring off it leaves the numpydoc-style ones for
     # numpydoc to render.
+    #
+    # This is a workaround for the package documenting itself in two styles.
+    # Converting those 56 sections to numpydoc would let napoleon be dropped
+    # entirely -- tracked in ASSESSMENT.md, "Tracked follow-up: one docstring
+    # style". Remove this extension once the last Google-style section is gone.
     "sphinx.ext.napoleon",
     "numpydoc",
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,90 @@
+music
+=====
+
+**Extreme-fidelity synthesis of musical elements.**
+
+``music`` generates and manipulates music and sound in LPCM audio. It
+implements the `MASS <https://github.com/ttm/mass/>`_ framework — *Music and
+Audio in Sample Sequences* — a collection of psychophysical descriptions of
+musical elements expressed as equations and corresponding Python routines.
+
+.. code-block:: python
+
+   import music
+
+   scale = [music.note(440 * 2 ** (i / 12), duration=0.4) for i in range(12)]
+   music.write_wav_mono(music.horizontal_stack(*scale), "chromatic.wav")
+
+What makes it precise
+---------------------
+
+**Sample-based synthesis.** State is updated at every sample. A note with a
+vibrato has a different instantaneous frequency at each of its samples, and the
+vibrato pattern is folded into the wavetable lookup rather than applied
+afterwards — so the rendered sound is as close as it can be to the mathematical
+model that describes it.
+
+**Musical structures**, with an emphasis on symmetry and discourse: permutation
+groups, change-ringing peals and plain changes.
+
+Every routine's docstring carries the equation it implements and cites the
+article it comes from. If you use this package, please cite:
+
+   Fabbri, Renato, et al. *Musical elements in the discrete-time representation
+   of sound.* arXiv preprint `arXiv:1412.6853 <https://arxiv.org/abs/1412.6853>`_
+   (2017).
+
+Install
+-------
+
+.. code-block:: console
+
+   pip install music
+
+Or from a checkout, which is convenient for hacking and debugging:
+
+.. code-block:: console
+
+   git clone https://github.com/ttm/music.git
+   pip install -e music
+
+Requires Python 3.10 or newer.
+
+Where things live
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Module
+     - What it holds
+   * - :doc:`core.synths <api>`
+     - Notes with vibrato, glissando, FM and Doppler; envelopes; noises
+   * - :doc:`core.filters <api>`
+     - ADSR, fades, FIR/IIR, reverb, loudness, stereo localization
+   * - :doc:`core.io <api>`
+     - Reading, writing and playing audio, mono and stereo
+   * - :doc:`structures <api>`
+     - Permutations, algebraic groups, change-ringing peals
+   * - :doc:`sequencer <api>`
+     - Scheduling notes into a timeline and rendering them
+   * - :doc:`utils <api>`
+     - Conversions, mixing, stacking, rhythm
+
+The whole public API is re-exported flat from the top level, so
+``music.note(...)`` works regardless of which submodule defines it.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   api
+
+.. toctree::
+   :caption: Project
+   :hidden:
+
+   GitHub <https://github.com/ttm/music>
+   Issues <https://github.com/ttm/music/issues>
+   MASS framework <https://github.com/ttm/mass/>

--- a/music/core/filters/impulse_response.py
+++ b/music/core/filters/impulse_response.py
@@ -63,9 +63,8 @@ def iir(sonic_vector, a, b):
 
     References
     ----------
-    .. [1] Fabbri, Renato, et al. "Musical elements in the
-    discrete-time representation of sound."
-    arXiv preprint arXiv:abs/1412.6853 (2017)
+    .. [1] Fabbri, Renato, et al. "Musical elements in the discrete-time
+           representation of sound." arXiv preprint arXiv:abs/1412.6853 (2017)
 
     """
     signal = sonic_vector

--- a/music/core/filters/localization.py
+++ b/music/core/filters/localization.py
@@ -43,8 +43,6 @@ def localize(sonic_vector=None, theta=0, distance=0, x=.1, y=.01,
     --------
     reverb : A reverberator.
     localize2 : a less naive implementation of localization by ITD and IID.
-    # FIXME: hrtf?
-    hrtf : performs localization by means of a Head Related Transfer Function.
 
     Examples
     --------
@@ -57,10 +55,14 @@ def localize(sonic_vector=None, theta=0, distance=0, x=.1, y=.01,
 
     Notes
     -----
+    A Head Related Transfer Function would localize more convincingly than
+    either this or localize2; none is implemented yet.
+
     Uses the most naive ITD and IID calculations as described in [1]. A less
     naive method is implemented in localize2(). Nonetheless, if dist is small
     enough (e.g. <.3), the perception of theta occurs and might be used.
     The advantages of this method are:
+
       - It is fast.
       - It is simple.
       - It is true to sound propagation phenomenon (although it does not
@@ -217,8 +219,6 @@ def localize2(sonic_vector=None, theta=-70, x=.1, y=.01, zeta=0.215,
     reverb : A reverberator.
     localize : a more naive and fast implementation of localization by ITD and
                IID.
-    # FIXME: hrtf?
-    hrtf : performs localization by means of a Head Related Transfer Function.
 
     Examples
     --------

--- a/music/legacy/IteratorSynth.py
+++ b/music/legacy/IteratorSynth.py
@@ -13,15 +13,16 @@ class IteratorSynth(CanonicalSynth):
         No additional attributes.
 
     Example:
+
     >>> isynth = M.IteratorSynth()
     >>> isynth.fundamental_frequency_sequence = [220, 400, 100, 500]
     >>> isynth.duration_sequence = [2, 1, 1.5]
     >>> isynth.vibrato_frequency_sequence = [3, 6.5, 10]
     >>> sounds = []
     >>> for i in range(300):
-            sounds += [isynth.renderIterate(tremolo_frequency=.2*i)]
+    ...     sounds += [isynth.renderIterate(tremolo_frequency=.2*i)]
     >>> import music.core.io
-    >>> music.core.io.write_wav_mono(M.H(*sounds),"./example.wav")
+    >>> music.core.io.write_wav_mono(M.H(*sounds), "./example.wav")
     """
 
     def renderIterate(self, **statevars):

--- a/music/utils.py
+++ b/music/utils.py
@@ -495,19 +495,20 @@ def mix_with_offset(
     duration : numeric
         The offset of the second sound, i.e. the displacement that
         the start of the second sound. (First sound has offset 0).
-        Might be negative, denoting to start sound2 |d| seconds before s1 ends.
+        Might be negative, denoting to start sound2 ``|d|`` seconds before
+    s1 ends.
     number_of_samples : int
     sample_rate : int
 
     Notes
     -----
-    if d<0, it should satisfy -d*fs < s1.shape[-1]
+    If ``d < 0``, it should satisfy ``-d*fs < s1.shape[-1]``.
 
-    TODO: enhance/recycle J_ and mix2 or delete them. TTM
+    TODO: enhance/recycle ``J_`` and mix2 or delete them. TTM
 
     See Also
     --------
-    (.functions).mix2 : a better mixer
+    mix2 : a better mixer
 
     """
     first_sonic_vector = np.array(first_sonic_vector)
@@ -554,14 +555,14 @@ def mix_with_offset_(*args: ArrayLike) -> NDArray[np.float64]:
 
     Parameters
     ----------
-    J_ receives a sequence of sonic vectors,
+    ``J_`` receives a sequence of sonic vectors,
     each a sequence of PCM samples.
     Or a sequence alternating the sonic vectors
     and their offsets.
 
     See Also
     --------
-    (.functions).mix2 : a better mixer
+    mix2 : a better mixer
 
     """
     # i = 0 # DEPRECATED
@@ -637,7 +638,7 @@ def pan_transitions(p=((1, 1), (1, 0), (0, 1), (1, 1)), d=(2, 2, 2),
     of channel c in p[i][c] and p[i+1][c].
 
     Consider only one of such fades
-    to understand the pan transition methods:
+    to understand the pan transition methods::
 
         'lin' fades linearly in and out:
             x*k_i+y*(1-k_i)
@@ -658,15 +659,19 @@ def pan_transitions(p=((1, 1), (1, 0), (0, 1), (1, 1)), d=(2, 2, 2),
     One immediate possibility is to maintain the expected
     tessiture of the sample amplitudes.
     Say p = [.5,1,0,.5] ~ [(1,1),(1,0),(0,1),(1,1)].
-    Then pi,pj = .5,1 might be performed as:
-    s1 = s1*.5 -> 0
-    s2 = s1*.5 -> (s1+s2)*.5
+    Then pi,pj = .5,1 might be performed as::
+
+        s1 = s1*.5 -> 0
+        s2 = s1*.5 -> (s1+s2)*.5
+
     Or through sinusoids and expotentials
 
     Make fast and slow fades and parameter transitions
     using weber-fechner and steven's laws.
-    E.g. pitch_trans = [pitch0*X**(i/Y) for i in range(12)]
-         pitch_trans = [pitch0 + X*i**Y for i in range(12)]
+    E.g.::
+
+        pitch_trans = [pitch0*X**(i/Y) for i in range(12)]
+        pitch_trans = [pitch0 + X*i**Y for i in range(12)]
 
     Examples
     --------
@@ -781,31 +786,32 @@ def profile(adict):
       The overal RMS mean of a scale is a hint of whether the variable
       is meant to be used (or usable as) PCM samples or parametrization.
       E.g.
+
         * Large arrays, i.e. with many elements, are usable as PCM samples.
-        If the mean is zero, and they are bound to [-1,1] or to some power
-        of 2, specially [-2**15, 2**15-1], it is probably PCM samples
-        synthesized or sampled or derivatives.
-        If it has more than one or two dimensions where the many samples are,
-        it might be a collection of audio samples with the sample size
+          If the mean is zero, and they are bound to [-1,1] or to some power
+          of 2, specially [-2**15, 2**15-1], it is probably PCM samples
+          synthesized or sampled or derivatives.
+          If it has more than one or two dimensions where the many samples
+          are, it might be a collection of audio samples with the sample size
 
         * Arrays with an offset (abs(mean) << 0) and small number of elements
-        are good candidates for parametrization.
-        They might be used for repetition, yielding a clear rhythm.
-        They might also be used to derive more ellaborate patterns,
-        such as by using the values of more then one arrays,
-        and using them simultaneously, often creating patterns
-        because of the different sizes of each array.
+          are good candidates for parametrization.
+          They might be used for repetition, yielding a clear rhythm.
+          They might also be used to derive more ellaborate patterns,
+          such as by using the values of more then one arrays,
+          and using them simultaneously, often creating patterns
+          because of the different sizes of each array.
 
         * Values in the order of hundreds and thousands are
-        candidates for frequency.
-        Values within zero and 150 are candidates for decibels,
-        and for absolute pitch or pitch interval through MIDI notes
-        and semitones count, respectively.
-        If the values are integers of very close to them,
-        or have many consecutive values deviating less then
-        10, it is more likely to be related to pitches.
-        If the consecutive values deviate by tens to about a hundred,
-        it is kin to decibels notation.
+          candidates for frequency.
+          Values within zero and 150 are candidates for decibels,
+          and for absolute pitch or pitch interval through MIDI notes
+          and semitones count, respectively.
+          If the values are integers of very close to them,
+          or have many consecutive values deviating less then
+          10, it is more likely to be related to pitches.
+          If the consecutive values deviate by tens to about a hundred,
+          it is kin to decibels notation.
 
     """
     # for key in adict:
@@ -858,14 +864,16 @@ def rhythm_to_durations(durations=(4, 2, 2, 4, 1, 1, 1, 1, 2, 2, 4),
     The durations parameter is considered to be in a temporal notation
     for durations/rhythm: each entry is a relative duration to
     be multiplied by the base duration given through duration,
-    BPM or total_duration.
-    >>> durs = [i*duration for i in durations]
+    BPM or total_duration::
+
+        durs = [i*duration for i in durations]
 
     The frequencies parameter is considered to be in a
     frequential notation: each entry is the number of the
     entry that fits a same duration (also given through duration,
-    BPM or total_duration).
-    >>> durs = [duration/i for i in freqs]
+    BPM or total_duration)::
+
+        durs = [duration/i for i in freqs]
 
     The examples above yield (two by two) the same sequences of durations
     by using duration=0.25 when in temporal notation or
@@ -873,7 +881,8 @@ def rhythm_to_durations(durations=(4, 2, 2, 4, 1, 1, 1, 1, 2, 2, 4),
 
     To facilitate the description of rhythms (e.g. for tuplets),
     some set of durations might be an iterable inside durations
-    or frequencies. In this case:
+    or frequencies. In this case::
+
         ### if mode is temporal:
             total_dur = cell[0]*duration
             # durations are proportional to remaining values:
@@ -889,7 +898,8 @@ def rhythm_to_durations(durations=(4, 2, 2, 4, 1, 1, 1, 1, 2, 2, 4),
     temporal or frequential notation and with cells for tuplets
     is the last two sequences of the examples.
 
-    It might be a good idea to incorporate also this notation:
+    It might be a good idea to incorporate also this notation::
+
         d2 = [1, 4, 1, 4]  # [quarter note + 4 sixteenth notes] x 2
 
     Cite the following article whenever you use this function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ optional-dependencies = { dev = [
     'pytest-cov >= 5.0',
     'mypy >= 1.8',
     'ruff >= 0.6',
+], docs = [
+    'sphinx >= 7.0',
+    'numpydoc >= 1.6',
+    'furo >= 2024.1.29',
 ] }
 classifiers = [
     'Programming Language :: Python :: 3',


### PR DESCRIPTION
Publishes the API reference to GitHub Pages, and fixes the docstrings that
turned out to be broken.

The docstrings were this package's strongest asset and its least visible one:
93% coverage, full numpydoc with the equations and the literature citation,
readable only by cloning the repo. This adds Sphinx + numpydoc + furo, deployed
from `master` to **https://ttm.github.io/music/**.

## Building it found real breakage

32 warnings, all genuine. **Four were serious** — `localize`, `localize2`,
`mix_with_offset` and `mix_with_offset_` **failed to import and so appeared
nowhere in the docs at all**:

- `localize` / `localize2` had a `# FIXME: hrtf?` comment sitting inside a
  `See Also` section, plus an entry for an `hrtf` function that does not exist.
- `mix_with_offset` / `mix_with_offset_` pointed at `(.functions).mix2`, which
  numpydoc cannot resolve.

Both raise during signature mangling, and autodoc drops the whole entry when
that happens. The HRTF remark is now a proper `Notes` paragraph, where it reads
better anyway.

The rest was malformed reStructuredText across about a dozen docstrings:

| Where | Problem |
|---|---|
| `profile` | bullet continuations indented under nothing |
| `rhythm_to_durations`, `pan_transitions` | pseudo-code blocks with no `::` literal marker |
| `mix_with_offset` | `\|d\|` read as a substitution reference, `J_` as a link target |
| `iir` | citation continuation lines not indented under `.. [1]` |
| `IteratorSynth` | doctest continuation missing its `...`, and a bare `*` opening inline emphasis |
| `localize` | bullet list opening with no blank line after its lead-in |

**The build is now warning-free, and CI runs it with `-W`** — a malformed
docstring fails the build rather than quietly rendering wrong.

## Two style systems

`music.structures` and `music.legacy` use Google-style docstrings — 56 sections
across seven files — which numpydoc cannot parse. Rather than convert them all
in this PR, `sphinx.ext.napoleon` is enabled ahead of numpydoc with
`napoleon_numpy_docstring = False`, so each style is handled by the extension
that renders it best. That cleared every `structures/` and `peals/` warning at
once.

Converting them for internal consistency is still worth doing, separately.

## The reference itself

All **69 exports**, grouped by role rather than dumped alphabetically —
notes, envelopes and noise, amplitude filters, spectral and spatial, io,
sequencing, structures, utilities, wavetables, singing, legacy. I checked the
grouping against `music.__all__` programmatically: no export undocumented, no
documented name that is not exported.

`viewcode` links each entry to its source, and `intersphinx` resolves numpy and
scipy types in signatures.

## Deployment

`.github/workflows/docs.yml` builds on every push and PR; it deploys only from
`master`. GitHub Pages is enabled with Actions as the source, so the first
push to `master` after this merges will publish the site.

## Verification

On a clean clone with `pip install -e '.[dev,docs]'`: ruff clean, mypy clean,
**129 tests pass**, coverage 61%, and `sphinx-build -W` succeeds with 69
generated pages. The working tree stays clean after a build.

The clean-clone check earned its keep here: `html_static_path` pointed at an
empty `docs/_static/`, which git does not track, so the strict build failed in a
fresh checkout while passing locally. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
