### PR TITLE
Make PlainChanges traverse the whole group, and test the group theory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: mypy music
 
       - name: Test
-        run: pytest -q --cov=music --cov-report=term-missing --cov-fail-under=58
+        run: pytest -q --cov=music --cov-report=term-missing --cov-fail-under=65

--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -363,10 +363,10 @@ file at a time, dropping `napoleon` only once the last Google-style section is g
 
 ## Open decisions
 
-Two changes on `fix/broken-exports` alter behaviour a caller could depend on.
-Neither is a bug fix that speaks for itself, so both are recorded here and in
-the changelog's "Needs a decision before release" section rather than being
-allowed to land silently.
+Three changes alter behaviour a caller could depend on. None is a bug fix
+that speaks for itself, so all are recorded here and in the changelog's
+"Needs a decision before release" section rather than being allowed to land
+silently.
 
 ### 1. `localize_linear()` — finish it, or leave it removed?
 
@@ -393,7 +393,35 @@ source, so C loses less than it appears to. **Recommendation: C for this
 release, then A or B deliberately.** Whichever is chosen, the fidelity tests
 give a template for asserting the delay against the ear geometry.
 
-### 2. The WAV quantiser's scale changed
+### 2. `PlainChanges` now returns a complete peal
+
+The default hunt count was hardcoded to two above four bells. A plain-changes
+peal needs `n - 3` hunts to traverse the whole symmetric group, so the default
+produced a fraction of it above five bells — **silently**:
+
+| bells | rows returned | `n!` | coverage |
+|---|---|---|---|
+| 3–5 | complete | | 100 % |
+| 6 | 120 | 720 | **16.7 %** |
+| 7 | 168 | 5,040 | **3.3 %** |
+| 8 | 224 | 40,320 | **0.6 %** |
+
+Two things say the complete peal was the intent. The code's own warning —
+*"peals are the same if there are N hunts less"* when `nhunts > nelements - 3`
+— already identifies `n - 3` as the saturation point; the default simply
+didn't use it. And `examples/geometric_music.py` asserts it in a comment:
+`# len(being.perms) == factorial(nel)`, true at four bells and silently false
+from six up.
+
+**The consequence to weigh:** anyone rendering from `peal_direct` at six bells
+or more now gets at least six times the material. A shorter peal is a valid
+method in campanology, so this is a change in default, not a bug fix in the
+algorithm — `nhunts=2` still gives the old behaviour.
+
+**Recommendation: keep it.** A structure named for traversing the permutations
+should traverse them, and nothing signalled that it wasn't.
+
+### 3. The WAV quantiser's scale changed
 
 Writing previously scaled by `2 ** (bit_depth - 1) - 1` while `read_wav`
 divided by `2 ** (bit_depth - 1)`. A write/read round trip therefore lost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [Unreleased]
 
 ### Needs a decision before release
-Two entries below change behaviour that callers may depend on. Both are
-deliberate, both are tracked, and neither should reach a release unreviewed.
+Three entries below change behaviour that callers may depend on. All are
+deliberate, all are tracked, and none should reach a release unreviewed.
 
 1. **`localize_linear()` is no longer exported** and raises
    `NotImplementedError`. It never worked — it crashed on its own defaults and
@@ -12,13 +12,27 @@ deliberate, both are tracked, and neither should reach a release unreviewed.
    time difference should be applied per sample. `localize()` handles a static
    position and `note_with_doppler()` a moving source, so the semantics wanted
    here are a design decision for the author, not something to infer.
-2. **The WAV quantiser's scale changed**, so files written from now on differ
+2. **`PlainChanges(n)` now returns a complete peal for every `n`.** The
+   default hunt count was hardcoded to two for more than four bells, so the
+   peal covered a fraction of the symmetric group above five: 120 of 720 rows
+   at six bells, 224 of 40320 at eight — silently. The default is now
+   `PlainChanges.saturating_hunts(n)`, i.e. `max(1, n - 3)`, which the code's
+   own warning already identified as the point past which extra hunts add
+   nothing. Anyone who was relying on the shorter peal can ask for it with
+   `nhunts=2`; anyone rendering from `peal_direct` at six bells or more will
+   get six times the material or more.
+3. **The WAV quantiser's scale changed**, so files written from now on differ
    from files written before by one LSB of gain (about 0.0003 dB — inaudible,
    but the bytes differ). This is what makes a write/read round trip unity
    gain, and `tests/test_fidelity.py` now pins that property. Anyone
    byte-comparing against previously rendered WAVs will see a diff.
 
 ### Fixed
+- `dist()` raised `IndexError` on the identity permutation, which has an empty
+  support. It now returns zero, there being no displaced pair to measure.
+- `PlainChanges(2)` and `PlainChanges(3)` warned that "peals are the same if
+  there are 2 hunts less", advising the removal of more hunts than existed:
+  the threshold was `nelements - 3`, which goes negative below four bells.
 - `stretches()` raised `AttributeError` on abandoned scratch code and could
   index one sample past the fragment it was resampling.
 - `trill()` raised `TypeError: 'module' object is not callable`. Submodules of
@@ -93,6 +107,14 @@ deliberate, both are tracked, and neither should reach a release unreviewed.
   56 sections across seven files. That is a workaround; converting them to
   numpydoc would let napoleon be dropped, and is tracked in `ASSESSMENT.md`
   under "Tracked follow-up: one docstring style".
+- `tests/test_structures.py`, asserting what campanology and group theory
+  actually guarantee about a plain-changes peal: that it visits each of the
+  `n!` permutations exactly once, that consecutive rows differ by a single
+  *adjacent* transposition — the constraint that makes a peal ringable — and
+  that it opens on rounds. Coverage of `structures/peals/plain_changes.py`
+  went from 10% to 86%, and of `structures/permutations.py` from 26% to 84%.
+- `PlainChanges.saturating_hunts(nelements)`, naming the rule that was
+  previously implicit in a warning message.
 - `tests/test_fidelity.py`, checking that the synthesized *samples* match the
   equations the docstrings cite, not merely that they have the right shape:
   `note` and `note_with_vibrato` against their closed forms sample for

--- a/music/structures/peals/plain_changes.py
+++ b/music/structures/peals/plain_changes.py
@@ -42,13 +42,35 @@ class PlainChanges:
         self.hunts = hunts
         self.nelements = nelements
 
+    @staticmethod
+    def saturating_hunts(nelements):
+        """
+        Number of hunts that yields a peal over the whole symmetric group.
+
+        For ``nelements`` bells this is ``nelements - 3``, floored at one.
+        Below it the peal is a proper subset of the permutations: with the
+        old default of two hunts, ``PlainChanges(6)`` produced 120 of the 720
+        rows and ``PlainChanges(8)`` produced 224 of 40320. Above it nothing
+        is gained, which is what the warning in initialize_hunts reports.
+
+        Parameters:
+            nelements (int): The number of elements.
+
+        Returns:
+            int: The saturating number of hunts.
+        """
+        return max(1, nelements - 3)
+
     def initialize_hunts(self, nelements=4, nhunts=None):
         """
         Initializes the hunts dictionary.
 
         Parameters:
             nelements (int, optional): The number of elements. Defaults to 4.
-            nhunts (int, optional): The number of hunts. Defaults to None.
+            nhunts (int, optional): The number of hunts. Defaults to the
+                value of saturating_hunts(nelements), which is the number
+                that makes the peal traverse every permutation exactly once.
+                Pass a smaller value deliberately for a shorter peal.
 
         Returns:
             dict: The hunts dictionary.
@@ -56,17 +78,15 @@ class PlainChanges:
         Raises:
             ValueError: If the number of hunts is invalid.
         """
+        saturating = self.saturating_hunts(nelements)
         if not nhunts:
-            if nelements > 4:
-                nhunts = 2
-            else:
-                nhunts = 1
+            nhunts = saturating
         assert nelements > 0
         if nhunts > nelements:
             raise ValueError("There cannot be more hunts than elements")
-        elif nhunts > nelements - 3:
+        elif nhunts > saturating:
             warnings.warn(
-                f"peals are the same if there are {nhunts - (nelements - 3)} "
+                f"peals are the same if there are {nhunts - saturating} "
                 "hunts less")
         hunts_dict = {}
         for hunt in range(nhunts):

--- a/music/structures/permutations.py
+++ b/music/structures/permutations.py
@@ -209,6 +209,11 @@ def dist(swap):
     of the permutation, the distance is calculated as the size of the
     permutation minus the difference.
 
+    This measures the two lowest displaced positions, so it is meaningful for
+    a transposition. For a permutation with a larger support the remaining
+    displaced positions are ignored. The identity displaces nothing and gives
+    zero.
+
     Examples
     --------
     >>> from sympy.combinatorics import Permutation
@@ -218,12 +223,19 @@ def dist(swap):
     >>> perm = Permutation([2, 0, 1])
     >>> dist(perm)
     1
+    >>> dist(Permutation([0, 1, 2]))  # the identity displaces nothing
+    0
     """
+    support = swap.support()
+    if len(support) < 2:
+        # The identity moves nothing, so there is no pair to measure
+        # between. Any other permutation displaces at least two elements.
+        return 0
     if swap.size % 2 == 0:
         half = swap.size / 2
     else:
         half = swap.size // 2 + 1
-    diff = abs(swap.support()[1] - swap.support()[0])
+    diff = abs(support[1] - support[0])
     if diff >= half:
         diff = swap.size - diff
     return diff

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -1,0 +1,151 @@
+"""Group-theoretic invariants for the permutation and peal structures.
+
+``music.structures`` is the part of this package with the fewest peers — there
+is little else in Python doing change ringing — and it was the least covered.
+The properties below are the ones campanology and group theory actually
+guarantee, so they pin the behaviour rather than merely exercising it.
+
+A plain-changes peal on ``n`` bells must:
+
+* traverse the whole symmetric group, visiting each of the ``n!``
+  permutations exactly once, and
+* move by a single *adjacent* transposition between consecutive rows, since a
+  ringer can only swap with a neighbour.
+
+References
+----------
+.. [1] Stedman's *Campanalogia*, and the change-ringing survey at
+       http://www.gutenberg.org/files/18567/18567-h/18567-h.htm
+"""
+
+import math
+import warnings
+
+import pytest
+from sympy.combinatorics import Permutation
+
+import music
+from music.structures.peals.plain_changes import PlainChanges
+
+# Beyond eight bells the peal is 40320 rows and the test turns into a
+# benchmark; the invariants do not become more convincing with size.
+SIZES = [2, 3, 4, 5, 6, 7]
+
+
+def _rows(peal):
+    """The peal's permutations as plain tuples, for set membership."""
+    return [tuple(row) for row in peal]
+
+
+def _is_adjacent_transposition(before, after):
+    """True when `after` is `before` with one neighbouring pair swapped."""
+    moved = [i for i, (x, y) in enumerate(zip(before, after)) if x != y]
+    if len(moved) != 2:
+        return False
+    first, second = moved
+    return (second - first == 1
+            and before[first] == after[second]
+            and before[second] == after[first])
+
+
+@pytest.mark.parametrize("nelements", SIZES)
+def test_peal_traverses_the_whole_symmetric_group(nelements):
+    """Regression: the default hunt count was hardcoded to 2 for n > 4, so
+    the peal covered a fraction of the group — 120 of 720 rows at n=6, and
+    224 of 40320 at n=8 — with nothing to indicate it."""
+    rows = _rows(PlainChanges(nelements).peal_direct)
+
+    assert len(rows) == math.factorial(nelements)
+    assert len(set(rows)) == len(rows), "a peal must not repeat a row"
+
+
+@pytest.mark.parametrize("nelements", SIZES)
+def test_every_change_swaps_neighbours(nelements):
+    """Consecutive rows differ by one adjacent transposition — the physical
+    constraint that makes a peal ringable."""
+    rows = _rows(PlainChanges(nelements).peal_direct)
+
+    for index, (before, after) in enumerate(zip(rows, rows[1:])):
+        assert _is_adjacent_transposition(before, after), (
+            f"row {index} -> {index + 1} is not an adjacent swap: "
+            f"{before} -> {after}"
+        )
+
+
+@pytest.mark.parametrize("nelements", SIZES)
+def test_peal_starts_from_rounds(nelements):
+    """A peal opens on rounds, the identity permutation."""
+    rows = _rows(PlainChanges(nelements).peal_direct)
+    assert rows[0] == tuple(range(nelements))
+
+
+@pytest.mark.parametrize("nelements", [4, 5, 6, 7])
+def test_saturating_hunts_is_the_least_that_completes_the_group(nelements):
+    """`saturating_hunts` claims to be the number of hunts at which the peal
+    becomes complete. One fewer must therefore fall short."""
+    saturating = PlainChanges.saturating_hunts(nelements)
+    assert saturating == max(1, nelements - 3)
+
+    complete = _rows(PlainChanges(nelements, nhunts=saturating).peal_direct)
+    assert len(complete) == math.factorial(nelements)
+
+    if saturating > 1:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fewer = _rows(
+                PlainChanges(nelements, nhunts=saturating - 1).peal_direct
+            )
+        assert len(fewer) < math.factorial(nelements)
+
+
+def test_more_hunts_than_saturating_warns_but_still_completes():
+    """Above the saturating count nothing is gained, which the code says out
+    loud. The peal must still be a valid traversal."""
+    with pytest.warns(UserWarning, match="hunts less"):
+        peal = PlainChanges(5, nhunts=4).peal_direct
+    rows = _rows(peal)
+    assert len(set(rows)) == len(rows)
+
+
+def test_more_hunts_than_elements_is_rejected():
+    with pytest.raises(ValueError, match="more hunts than elements"):
+        PlainChanges(4, nhunts=5)
+
+
+@pytest.mark.parametrize("nelements", [2, 3, 4])
+def test_small_peals_do_not_warn_about_negative_hunts(nelements):
+    """Regression: the warning threshold was `nelements - 3`, which goes
+    negative below four bells, so PlainChanges(2) advised removing two of
+    its one hunt."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        PlainChanges(nelements)
+
+
+# --------------------------------------------------------------------------
+# Permutation helpers
+# --------------------------------------------------------------------------
+
+def test_dist_counts_displaced_elements():
+    """dist reports how far a permutation moves things."""
+    assert music.dist(Permutation([0, 1, 2])) == 0
+    assert music.dist(Permutation([1, 0, 2])) == 1
+
+
+def test_transpose_permutation_shifts_the_support():
+    """Transposing by one moves every moved index up by one."""
+    transposed = music.transpose_permutation(Permutation([1, 0, 2]))
+    assert transposed.support() == [1, 2]
+
+
+def test_interesting_permutations_are_permutations_of_the_domain():
+    """Whatever families it builds, each must be a genuine permutation."""
+    perms = music.InterestingPermutations(nelements=4)
+    families = [value for name, value in vars(perms).items()
+                if isinstance(value, list) and value
+                and isinstance(value[0], Permutation)]
+    assert families, "expected at least one family of permutations"
+
+    for family in families:
+        for permutation in family:
+            assert max(permutation.array_form or [0]) < 4


### PR DESCRIPTION
`music.structures` is the part of this package with the fewest peers — there is
little else in Python doing change ringing — and it was the least covered:
`plain_changes.py` at 10%, `permutations.py` at 26%. Checking what campanology
actually guarantees found two defects.

## ⚠️ A behaviour change that needs your decision

Recorded in `CHANGELOG.md` under **"Needs a decision before release"** and
analysed in `ASSESSMENT.md` under **Open decisions**, alongside the two already
tracked.

**`PlainChanges(n)` now returns a complete peal.** The default hunt count was
hardcoded to two above four bells, but a plain-changes peal needs `n - 3` hunts
to traverse the symmetric group. Above five bells the default returned a
fraction of it, silently:

| bells | rows returned | `n!` | coverage |
|---|---|---|---|
| 3–5 | complete | | 100% |
| 6 | 120 | 720 | **16.7%** |
| 7 | 168 | 5,040 | **3.3%** |
| 8 | 224 | 40,320 | **0.6%** |

Two things say the complete peal was the intent:

1. **The code's own warning** — `"peals are the same if there are N hunts
   less"` when `nhunts > nelements - 3` — already names `n - 3` as the
   saturation point. The default just didn't use it.
2. **`examples/geometric_music.py` asserts it in a comment**:
   `# len(being.perms) == factorial(nel)`. True at four bells, silently false
   from six up.

The rule is now `PlainChanges.saturating_hunts(n)` — named rather than implicit
— and the default uses it. **`nhunts=2` still gives the old, shorter peal**, so
nothing is lost; a shorter peal is a valid method in campanology, which is why
this is a change of default rather than a bug fix in the algorithm.

The consequence to weigh: anyone rendering from `peal_direct` at six bells or
more now gets at least six times the material.

## Two straightforward fixes

- **`PlainChanges(2)` and `(3)` warned nonsensically** — `"peals are the same
  if there are 2 hunts less"`, advising the removal of more hunts than existed.
  The threshold was `nelements - 3`, which goes negative below four bells.
- **`dist()` raised `IndexError` on the identity permutation**, whose support
  is empty. It now returns zero, there being no displaced pair to measure.

## Testing the group theory, not the outputs

`tests/test_structures.py` asserts what a plain-changes peal must satisfy
rather than pinning whatever it currently emits:

- it visits each of the `n!` permutations **exactly once**;
- consecutive rows differ by a single **adjacent** transposition — the physical
  constraint that makes a peal ringable, since a ringer can only swap with a
  neighbour;
- it opens on rounds;
- `saturating_hunts` really is the *least* count that completes the group — one
  fewer must fall short.

Verified for 2 through 7 bells (8 is 40320 rows and turns the suite into a
benchmark without making the invariants more convincing).

| | before | after |
|---|---|---|
| `plain_changes.py` | 10% | **86%** |
| `permutations.py` | 26% | **84%** |
| Overall | 61% | **68%** |
| Tests | 129 | **159** |

Coverage floor raised 58% → 65%.

## Verification

Clean clone, `pip install -e '.[dev,docs]'`: ruff clean, mypy clean, 159 tests
pass, docs build with `-W`. 9 of 10 examples run clean; `singing_demo` needs
the external eCantorix engine, unchanged.

The `-W` docs gate earned its keep again — I added a `Notes` section to `dist`
that already had one, and the build caught the duplicate before it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
