### PR TITLE
Enable check_untyped_defs and fix all 177 errors it surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: mypy music
 
       - name: Test
-        run: pytest -q --cov=music --cov-report=term-missing --cov-fail-under=65
+        run: pytest -q --cov=music --cov-report=term-missing --cov-fail-under=80

--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -270,10 +270,11 @@ Ordered by return on effort. Phase 1 is roughly a day and removes every "Terribl
 
 5. **Add GitHub Actions**: `pytest` + `ruff` + `mypy` on 3.10/3.11/3.12/3.13, on every push
    and PR. Nothing else in this list holds without it.
-6. **Turn on `check_untyped_defs = true`** in `[tool.mypy]`, then work the 184 errors down
-   module by module. **156 of the 184 errors (85 %) are in `legacy/`**, so excluding that
-   package initially leaves 28 errors across the rest of the codebase — a single sitting.
-   Ratchet, don't bulk-fix.
+6. **Turn on `check_untyped_defs = true`** in `[tool.mypy]`, then work the errors down
+   module by module. *(Done — all 177 fixed and the flag enforced in CI. The errors were
+   not merely noise: they pointed at an exported function whose mono branch had never run,
+   a documented `localize2` method that always crashed, and a demonstration piece that
+   bound a class where it meant an instance.)*
 7. **Add `ruff` with a committed config**; auto-fix the 79 mechanical findings, triage the rest.
 8. **Add `music/py.typed`** and a `__version__` single-sourced from package metadata.
 9. **Set a coverage floor at the current 43 %** and raise it as you go, so it cannot regress.
@@ -302,7 +303,7 @@ Ordered by return on effort. Phase 1 is roughly a day and removes every "Terribl
 16. **Move the module-level RNG defaults into the function bodies** (`if sonic_vector is None:
     ...`) and drop 2.4 MB and the import cost.
 17. **Remove `exec` from `CanonicalSynth`** — explicit attribute assignment restores ~40 type
-    errors' worth of visibility.
+    errors' worth of visibility. *(Done, along with the other two `exec` sites.)*
 18. **Rework `setup_engine()`** to clone into a user cache dir (`platformdirs.user_cache_dir`),
     never `site-packages`; document the `git`/`make`/`perl`/`espeak` system dependencies and
     check for them with a clear error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ deliberate, all are tracked, and none should reach a release unreviewed.
    byte-comparing against previously rendered WAVs will see a diff.
 
 ### Fixed
+- The mono branch of `note_with_vibrato_seq_localization()` had never run.
+  Three faults, one behind the other: a per-segment value was assigned over
+  the accumulator that the next line appended to, raising `AttributeError`;
+  the `durations` parameter was clobbered by a local of the same name, so the
+  next iteration indexed into an array; and `extend` was used where the
+  stereo branch appends, leaving an inhomogeneous list for `np.prod`. Each
+  fix is modelled on the working stereo branch beside it.
+- `localize2(method="brute")` computed its buffer size as a float, which
+  `np.zeros` refuses. The documented alternative to "ifft" had never worked.
+- `music.legacy.pieces.testSong2` bound the *class* `CanonicalSynth` rather
+  than an instance, so every call in the module was an unbound method missing
+  `self`. The piece could not run at all; it now does.
+- `CanonicalSynth.adsrApply()` gave the sustain stage a negative length on
+  notes shorter than the attack, decay and release combined -- the same fault
+  fixed earlier in `music.adsr`. The stages are compressed proportionally.
 - `setup_engine()` cloned the eCantorix engine into the installed package
   directory, which fails on a read-only install, in a container, and for any
   second user of a shared `site-packages`, and which a `pip` upgrade discards.
@@ -107,6 +122,15 @@ deliberate, all are tracked, and none should reach a release unreviewed.
   exactly representable levels survive a round trip unchanged.
 
 ### Changed
+- `check_untyped_defs` is on. Most of this package is unannotated, and mypy
+  skips the bodies of unannotated functions by default, so it had been
+  reporting success while inspecting about a sixth of the code. Turning the
+  flag on surfaced 177 errors; all are fixed, and CI now enforces it.
+- `CanonicalSynth`, `Being` and `TestSong2` build their attributes by copying
+  local variables onto the instance. Three `exec("self.{}={}")` calls did
+  that; they are now plain `vars(self).update(...)`, and the attributes each
+  class ends up with are declared at class level, so the surface is
+  discoverable rather than implicit. `tests/test_legacy.py` pins it.
 - Every docstring is numpydoc now. `music.structures`, `music.legacy` and
   `music.tables` used Google style -- `Attributes:`, `Parameters:`, `Returns:`
   with a trailing colon -- across 60 sections in eight files, which numpydoc
@@ -140,6 +164,12 @@ deliberate, all are tracked, and none should reach a release unreviewed.
 - `music/singing/paths.py`, a single source of truth for where the engine
   lives and what it needs. The path was previously computed twice, in
   `bootstrap.py` and in `perform.py`, both at import time.
+- `tests/test_legacy.py`, covering the legacy synthesizers, which were the
+  least-tested modules in the package. `CanonicalSynth` went from 11% to 97%,
+  `IteratorSynth` from 25% to 100% and `testSong2` from 0% to 100%.
+- The public API sweep now exercises non-default branches -- both channel
+  modes and both localisation methods -- which is where the faults above
+  were hiding.
 - `tests/test_singing.py`, covering path resolution, the dependency check and
   the failure modes, none of which need the engine itself. It replaces
   `test_bootstrap.py` and `test_perform_failures.py`, which patched module

--- a/music/core/filters/impulse_response.py
+++ b/music/core/filters/impulse_response.py
@@ -68,7 +68,7 @@ def iir(sonic_vector, a, b):
 
     """
     signal = sonic_vector
-    signal_ = []
+    signal_: list = []
     for i in range(len(signal)):
         samples_a = signal[i::-1][:len(a)]
         a_coeffs = a[:i + 1]

--- a/music/core/filters/localization.py
+++ b/music/core/filters/localization.py
@@ -288,7 +288,10 @@ def localize2(sonic_vector=None, theta=-70, x=.1, y=.01, zeta=0.215,
             len(sonic_vector)
             + sample_rate * foo * np.sin(abs(theta_)) / speed
         ))
-        s = np.zeros((2, maxsize))
+        # Annotated without a shape: it is rebuilt by np.vstack further
+        # down, and numpy's stubs narrow np.zeros((2, n)) to a 2-tuple shape
+        # that the vstack result does not match.
+        s: np.ndarray = np.zeros((2, maxsize))
 
     if method == "ifft":
         # ITD implies a phase change

--- a/music/core/filters/localization.py
+++ b/music/core/filters/localization.py
@@ -273,7 +273,6 @@ def localize2(sonic_vector=None, theta=-70, x=.1, y=.01, zeta=0.215,
         anglesr = np.copy(angles)
     else:
         # limit the number of coeffs considered
-        s = []
         energy = np.cumsum(norms[:max_coef] ** 2)
         p = 0.01
         cutoff = energy.max() * (1 - p)
@@ -283,8 +282,12 @@ def localize2(sonic_vector=None, theta=-70, x=.1, y=.01, zeta=0.215,
             foo = .3
         else:
             foo = .2
-        maxsize = len(sonic_vector) + sample_rate * foo * np.sin(
-                abs(theta_)) / speed
+        # A sample count, so a whole number of them: it sizes the buffers
+        # below, all of which np.zeros refuses to build from a float.
+        maxsize = int(np.ceil(
+            len(sonic_vector)
+            + sample_rate * foo * np.sin(abs(theta_)) / speed
+        ))
         s = np.zeros((2, maxsize))
 
     if method == "ifft":

--- a/music/core/synths/envelopes.py
+++ b/music/core/synths/envelopes.py
@@ -257,7 +257,7 @@ def tremolos(durations=((3, 4, 5), (2, 3, 7, 4)),
         [np.array(wt) for wt in row]
         for row in waveform_tables
     ]
-    t_ = []
+    t_: list = []
     if number_of_samples:
         for i, ns in enumerate(number_of_samples):
             t_.append([])

--- a/music/core/synths/noises.py
+++ b/music/core/synths/noises.py
@@ -1,5 +1,5 @@
 """Module for the synthesis of noises and silences."""
-from numbers import Number
+from numbers import Real
 import numpy as np
 import music
 
@@ -52,6 +52,7 @@ def noise(noise_type="brown", duration=2, min_freq=15, max_freq=15000,
         length = number_of_samples
     else:
         length = int(duration * sample_rate)
+    prog: float
     if noise_type == "white":
         prog = 0
     elif noise_type == "pink":
@@ -64,8 +65,10 @@ def noise(noise_type="brown", duration=2, min_freq=15, max_freq=15000,
         prog = 6
     elif noise_type == "black":
         prog = -12
-    elif isinstance(noise_type, Number):
-        prog = noise_type
+    elif isinstance(noise_type, Real):
+        # Real rather than Number: a complex gain per octave is meaningless,
+        # and float() would reject it anyway.
+        prog = float(noise_type)
     else:
         raise ValueError(
             "Set ntype to a number or one of the following strings: "

--- a/music/core/synths/notes.py
+++ b/music/core/synths/notes.py
@@ -605,7 +605,7 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
 
     """
     # pitch transition contributions
-    f_ = []
+    pitch_parts = []
     for i, dur in enumerate(durations[0]):
         lambda_ = int(sample_rate * dur)
         samples = np.arange(lambda_)
@@ -614,11 +614,11 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
             f = f1 * (f2 / f1) ** ((samples / (lambda_ - 1)) ** alpha[0][i])
         else:
             f = f1 * (f2 / f1) ** (samples / (lambda_ - 1))
-        f_.append(f)
-    ft = np.hstack(f_)
+        pitch_parts.append(f)
+    ft = np.hstack(pitch_parts)
 
     # vibrato contributions
-    v_ = []
+    v_: list = []
     for i, vib in enumerate(durations[1:-1]):
         v_ = []
         for j, dur in enumerate(vib):
@@ -644,8 +644,8 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
     # dl_ = []
     # dr_ = []
     # d_ = []
-    f_ = []
-    iid_a = []
+    f_parts: list = []
+    iid_parts: list = []
     if stereo:
         for i in range(len(method)):
             m = method[i]
@@ -665,7 +665,7 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
                     lambda_d
             dl = np.sqrt((xi + zeta / 2) ** 2 + yi ** 2)
             dr = np.sqrt((xi - zeta / 2) ** 2 + yi ** 2)
-            if len(f_) == 0:
+            if len(f_parts) == 0:
                 itd0 = (dl[0] - dr[0]) / speed
                 lambda_itd = itd0 * sample_rate
             iid_al = 1 / dl
@@ -676,8 +676,8 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
             fl = speed / (speed + vsl)
             fr = speed / (speed + vsr)
 
-            f_.append(np.vstack((fl, fr)))
-            iid_a.append(np.vstack((iid_al[:-1], iid_ar[:-1])))
+            f_parts.append(np.vstack((fl, fr)))
+            iid_parts.append(np.vstack((iid_al[:-1], iid_ar[:-1])))
     else:
         for i in range(len(method)):
             m = method[i]
@@ -695,17 +695,22 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
                     lambda_d
                 yi = y[i] + (y[i + 1] - y[i]) * np.arange(lambda_d + 1) / \
                     lambda_d
-            durations = np.sqrt(xi ** 2 + yi ** 2)
-            iid = 1 / durations
+            # The distance to the listener, as dl and dr are in the stereo
+            # branch above. Naming it `durations` clobbered the parameter
+            # that the next iteration reads lambda_d from.
+            dm = np.sqrt(xi ** 2 + yi ** 2)
+            iid = 1 / dm
 
             # velocities at each point
-            vs = sample_rate * (durations[1:] - durations[:-1])
-            f_ = speed / (speed + vs)
+            vs = sample_rate * (dm[1:] - dm[:-1])
+            # A per-segment value, as fl and fr are above; assigning it
+            # to the accumulator overwrote what the next line appends to.
+            fm = speed / (speed + vs)
 
-            f_.append(f_)
-            iid_a.append(iid[:-1])
-    f_ = np.hstack(f_)
-    iid_a = np.hstack(iid_a)
+            f_parts.append(fm)
+            iid_parts.append(iid[:-1])
+    f_ = np.hstack(f_parts)
+    iid_a = np.hstack(iid_parts)
 
     # find maximum size, fill others with ones
     amax = max([len(i) if len(i.shape) == 1 else len(i[0]) for i in v_ + [f_]])
@@ -719,8 +724,10 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
 
     length = len(waveform_tables[0][0])
     if not stereo:
-        v_.extend(f_)
-        f = np.prod(v_, axis=0)
+        # One more contribution, as `v_ + [f_[0]]` does per channel in the
+        # stereo branch below; extend() spread f_ into its 600k scalars and
+        # left v_ inhomogeneous for np.prod.
+        f = np.prod(v_ + [f_], axis=0)
         gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
         s_ = []
         pointer = 0
@@ -975,7 +982,7 @@ def note_with_vibratos_glissandos(freqs=(220, 440, 330),
     ft = np.hstack(f_)
 
     # vibrato contributions
-    v_ = []
+    v_: list = []
     for i, vib in enumerate(durations[1:]):
         v_ = []
         for j, dur in enumerate(vib):

--- a/music/legacy/CanonicalSynth.py
+++ b/music/legacy/CanonicalSynth.py
@@ -1,7 +1,17 @@
 """Reference synthesizer demonstrating basic techniques."""
 
+from typing import Any
+
 import numpy as n
 import music as M
+
+
+def _fit(stage, count):
+    """Resample an envelope stage to `count` samples, keeping its shape."""
+    if count <= 0:
+        return stage[:0]
+    indexes = n.linspace(0, len(stage) - 1, count).round().astype(n.int64)
+    return stage[indexes]
 
 
 class CanonicalSynth:
@@ -34,6 +44,38 @@ class CanonicalSynth:
     >>> cs =  CanonicalSynth()
     # TODO: develop example
     """
+
+    # Assigned by synthSetup and adsrSetup, which copy their locals onto the
+    # instance. Declared here so they are discoverable rather than implicit;
+    # absorbState can add further attributes beyond these.
+    tables: Any
+    samplerate: int
+    table: n.ndarray
+    vibrato_table: n.ndarray
+    tremolo_table: n.ndarray
+    vibrato_depth: float
+    vibrato_frequency: float
+    tremolo_depth: float
+    tremolo_frequency: float
+    duration: float
+    fundamental_frequency: float
+    vibrato: bool
+    tremolo: bool
+    A: float
+    S: float
+    D: n.ndarray
+    R: n.ndarray
+    A_: n.ndarray
+    A_i: n.ndarray
+    D_i: n.ndarray
+    R_i: n.ndarray
+    ii: n.ndarray
+    Lambda_A: int
+    Lambda_D: int
+    Lambda_R: int
+    a_S: float
+    render_note: bool
+    adsr_method: str
 
     def __init__(s, **statevars):
         """
@@ -98,8 +140,7 @@ class CanonicalSynth:
             tremolo = False
         locals_ = locals().copy()
         del locals_["self"]
-        for i in locals_:
-            exec("self.{}={}".format(i, i))
+        vars(self).update(locals_)
 
     def adsrSetup(self, A=100., D=40, S=-5., R=50, render_note=False,
                   adsr_method="absolute"):
@@ -137,8 +178,7 @@ class CanonicalSynth:
         R_i = n.copy(R)
         locals_ = locals().copy()
         del locals_["self"]
-        for i in locals_:
-            exec("self.{}={}".format(i, i))
+        vars(self).update(locals_)
 
     def adsrApply(self, audio_vec):
         """
@@ -155,9 +195,22 @@ class CanonicalSynth:
             Audio vector with applied ADSR envelope.
         """
         Lambda = len(audio_vec)
-        S = n.ones(Lambda - self.Lambda_R - (self.Lambda_A + self.Lambda_D),
-                   dtype=n.float64) * self.a_S
-        envelope = n.hstack((self.A_i, self.D_i, S, self.R_i))
+        attack, decay, release = self.A_i, self.D_i, self.R_i
+
+        # The attack, decay and release stages cannot outlast the note they
+        # shape: compress them proportionally when it is too short, rather
+        # than leaving the sustain stage with a negative length.
+        stages = len(attack) + len(decay) + len(release)
+        if stages > Lambda:
+            ratio = Lambda / stages
+            attack = _fit(attack, int(len(attack) * ratio))
+            decay = _fit(decay, int(len(decay) * ratio))
+            release = _fit(release, int(len(release) * ratio))
+
+        sustain = n.ones(
+            Lambda - len(attack) - len(decay) - len(release), dtype=n.float64
+        ) * self.a_S
+        envelope = n.hstack((attack, decay, sustain, release))
         return envelope * audio_vec
 
     def render(self, **statevars):

--- a/music/legacy/classes.py
+++ b/music/legacy/classes.py
@@ -1,5 +1,7 @@
 """Utility classes supporting the legacy synthesizer API."""
 
+from typing import Any
+
 import numpy as n
 import logging
 
@@ -71,6 +73,38 @@ def ADV(note_dict={}, adsr_dict={}):
 
 
 class Being:
+    """A configurable sequence walker that renders notes.
+
+    Attributes are assigned from outside as well as within: the examples set
+    ``perms``, ``domain``, ``curseq`` and the parameter sequences directly
+    before calling ``walk`` or ``render``. They are declared here so that
+    surface is discoverable rather than implicit.
+    """
+
+    # startBeing seeds these as lists; mkArray replaces them with arrays.
+    dscale: Any
+    d_: Any
+    f_: Any
+    fv_: Any
+    nu_: Any
+    tab_: Any
+    A_: Any
+    D_: Any
+    S_: Any
+    R_: Any
+    total_notes: int
+    resources: dict
+
+    # Set by the caller, or by walk/stay, before rendering.
+    grid: Any
+    fgrid: Any
+    pointer: int
+    fpointer: int
+    seqsize: int
+    domain: Any
+    curseq: str
+    perms: Any
+
     def __init__(self):
         rhythm = [1.]  # repetition of one second
         rhythm2 = [1/2, 1/2]  # repetition of one second

--- a/music/legacy/pieces/testSong2.py
+++ b/music/legacy/pieces/testSong2.py
@@ -2,7 +2,9 @@
 
 import music as M
 import numpy as np
-synth = M.legacy.CanonicalSynth
+# An instance, not the class: every call below is an instance method, so
+# binding the class here made the whole module unrunnable.
+synth = M.legacy.CanonicalSynth()
 
 
 class TestSong2:
@@ -15,6 +17,9 @@ class TestSong2:
     >>> test_song = TestSong2()
     # TODO: Add more examples
     """
+
+    # __init__ copies its locals onto the instance; render() reads this one.
+    notes_: list
     def __init__(self):
         """
         Initializes the TestSong2 instance and generates various sounds using
@@ -232,8 +237,7 @@ class TestSong2:
         # vibrosong=H(notes_+notes)
         locals_ = locals().copy()
         del locals_["self"]
-        for i in locals_:
-            exec("self.{}={}".format(i, i))
+        vars(self).update(locals_)
 
     def render(self):
         A = synth.adsrApply

--- a/music/singing/perform.py
+++ b/music/singing/perform.py
@@ -104,8 +104,9 @@ class Notes:
                                                        notes_all)])
 
     def convert(self, notes, reference):
-        if 'notes_dict' not in dir(self):
+        if self.notes_dict is None:
             self.make_dict()
+        assert self.notes_dict is not None  # make_dict always assigns it
         notes_ = [reference + note for note in notes]
         notes__ = [self.notes_dict[note] for note in notes_]
         return notes__

--- a/music/structures/peals/base.py
+++ b/music/structures/peals/base.py
@@ -56,6 +56,11 @@ class GenericPeal:
                 f"no peal named {peal!r}; defined: {sorted(self.peals)}"
             )
         if domain is None:
+            if self.nelements is None:
+                raise ValueError(
+                    "nelements has not been set, so no default domain can "
+                    "be built; pass domain explicitly"
+                )
             domain = list(range(self.nelements))
         return [i(domain) for i in self.peals[peal]]
 
@@ -74,6 +79,11 @@ class GenericPeal:
                 "no peals have been defined on this object yet"
             )
         if domain is None:
+            if self.nelements is None:
+                raise ValueError(
+                    "nelements has not been set, so no default domain can "
+                    "be built; pass domain explicitly"
+                )
             domain = list(range(self.nelements))
         acted_peals = {}
         for peal in self.peals:

--- a/music/structures/peals/plain_changes.py
+++ b/music/structures/peals/plain_changes.py
@@ -243,6 +243,7 @@ class PlainChanges:
         """
         if domain is None:
             domain = list(range(self.nelements))
+        assert self.peals is not None
         acted_peals = {}
         for peal in self.peals:
             acted_peals[peal + "_acted"] = [i(domain)

--- a/music/structures/permutations.py
+++ b/music/structures/permutations.py
@@ -50,18 +50,22 @@ class InterestingPermutations:
         Generates permutations with full symmetry.
 
     """
+    # Populated by the get_* methods that __init__ calls. vertex_mirrors and
+    # edge_mirrors stay None for an odd number of elements, which have
+    # neither, so those keep their placeholder.
+    permutations_by_sizes: list
+    permutations: list
+    neighbor_swaps: list
+    swaps_by_stepsizes: list
+    swaps_as_comes: list
+    swaps: list
+    rotations: list
+    mirrors: list
+    dihedral: list
+
     def __init__(self, nelements=4, method="dimino"):
-        self.permutations_by_sizes = None
-        self.permutations = None
-        self.neighbor_swaps = None
-        self.swaps_by_stepsizes = None
-        self.swaps_as_comes = None
         self.vertex_mirrors = None
         self.edge_mirrors = None
-        self.swaps = None
-        self.rotations = None
-        self.mirrors = None
-        self.dihedral = None
         self.alternations_by_sizes = None
         self.alternations_complement = None
         self.alternations = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,7 @@ select = ['E', 'W', 'F']
 # fail to parse numpy's own stubs when run on 3.12+.
 files = ['music']
 ignore_missing_imports = true
+# Most of this package is unannotated, and without this mypy skips those
+# function bodies entirely -- it was reporting success while inspecting
+# about a sixth of the code.
+check_untyped_defs = true

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,0 +1,166 @@
+"""Behaviour of the legacy synthesizers.
+
+These were the least covered modules in the package. CanonicalSynth builds
+its attributes dynamically, which is what made them invisible to mypy, so
+the surface is pinned here before it is made explicit.
+"""
+
+import numpy as np
+import pytest
+
+import music
+from music.legacy.CanonicalSynth import CanonicalSynth
+from music.legacy.IteratorSynth import IteratorSynth
+
+#: Every attribute a default CanonicalSynth ends up carrying. Assigning
+#: these is the whole job of synthSetup and adsrSetup.
+EXPECTED_ATTRIBUTES = {
+    "A", "A_", "A_i", "D", "D_i", "Lambda_A", "Lambda_D", "Lambda_R",
+    "R", "R_i", "S", "a_S", "adsr_method", "duration",
+    "fundamental_frequency", "ii", "render_note", "samplerate", "table",
+    "tables", "tremolo", "tremolo_depth", "tremolo_frequency",
+    "tremolo_table", "vibrato", "vibrato_depth", "vibrato_frequency",
+    "vibrato_table",
+}
+
+#: The subset actually read elsewhere in the package.
+READ_ATTRIBUTES = {
+    "A_i", "D_i", "R_i", "Lambda_A", "Lambda_D", "Lambda_R", "a_S",
+    "duration", "fundamental_frequency", "samplerate", "table", "tables",
+    "tremolo_depth", "tremolo_frequency", "tremolo_table", "vibrato_depth",
+    "vibrato_frequency", "vibrato_table",
+}
+
+
+def test_default_synth_carries_the_expected_attributes():
+    """Pins the surface that synthSetup and adsrSetup assign."""
+    assert set(vars(CanonicalSynth())) == EXPECTED_ATTRIBUTES
+
+
+def test_the_attributes_read_elsewhere_all_exist():
+    synth = CanonicalSynth()
+    for name in sorted(READ_ATTRIBUTES):
+        assert hasattr(synth, name), name
+
+
+def test_default_attribute_values():
+    """The defaults, so a refactor of how they are assigned cannot drift."""
+    synth = CanonicalSynth()
+    assert synth.samplerate == 44100
+    assert synth.fundamental_frequency == 220
+    assert synth.duration == 2
+    assert synth.vibrato_depth == pytest.approx(0.1)
+    assert synth.vibrato_frequency == pytest.approx(2.0)
+    assert synth.tremolo_depth == pytest.approx(3.0)
+    assert synth.tremolo_frequency == pytest.approx(0.2)
+    assert synth.a_S == pytest.approx(10 ** (-5.0 / 20))
+    assert synth.Lambda_A == 4410
+    assert synth.Lambda_D == 1764
+    assert synth.Lambda_R == 2205
+    for name in ("A_i", "D_i", "R_i", "table", "vibrato_table",
+                 "tremolo_table"):
+        assert isinstance(getattr(synth, name), np.ndarray), name
+
+
+def test_absorb_state_sets_arbitrary_attributes():
+    """The synth is parametrised by keyword on any call, and remembers."""
+    synth = CanonicalSynth(anything=7)
+    assert synth.anything == 7
+    synth.absorbState(other="value")
+    assert synth.other == "value"
+
+
+def test_state_passed_to_the_constructor_survives_setup():
+    synth = CanonicalSynth(samplerate=22050)
+    assert synth.samplerate == 22050
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+def test_raw_render_produces_audio_of_the_requested_duration():
+    synth = CanonicalSynth()
+    samples = synth.rawRender(duration=0.05)
+    assert isinstance(samples, np.ndarray)
+    assert samples.shape[0] == pytest.approx(0.05 * synth.samplerate, abs=2)
+    assert np.isfinite(samples).all()
+
+
+def test_render_and_render2_produce_finite_audio():
+    synth = CanonicalSynth()
+    for method in (synth.render, synth.render2):
+        samples = method(duration=0.05)
+        assert isinstance(samples, np.ndarray)
+        assert samples.size > 0
+        assert np.isfinite(samples).all()
+
+
+def test_tremolo_envelope_spans_its_depth_in_decibels():
+    """The envelope is 10 ** (pattern * depth / 20), so over at least one
+    full cycle it swings between +/- tremolo_depth around unity gain."""
+    synth = CanonicalSynth()
+    depth = synth.tremolo_depth
+    # One whole cycle: the 0.2 Hz default would need five seconds.
+    envelope = synth.tremoloEnvelope(duration=1.0, tremolo_frequency=4.0)
+
+    assert np.isfinite(envelope).all()
+    assert envelope.min() == pytest.approx(10 ** (-depth / 20), rel=1e-3)
+    assert envelope.max() == pytest.approx(10 ** (depth / 20), rel=1e-3)
+
+
+def test_adsr_apply_shapes_the_note_it_is_given():
+    synth = CanonicalSynth()
+    note = synth.rawRender(duration=0.5)
+    shaped = synth.adsrApply(note)
+    assert shaped.shape == note.shape
+    assert np.isfinite(shaped).all()
+    # The attack starts from silence, so the opening sample is quieter.
+    assert abs(shaped[0]) <= abs(note[0]) + 1e-12
+
+
+# --------------------------------------------------------------------------
+# IteratorSynth
+# --------------------------------------------------------------------------
+
+def test_iterator_synth_cycles_through_its_sequences():
+    synth = IteratorSynth()
+    synth.fundamental_frequency_sequence = [220, 440]
+    synth.duration_sequence = [0.05]
+    first = synth.renderIterate()
+    second = synth.renderIterate()
+    assert np.isfinite(first).all() and np.isfinite(second).all()
+    assert first.size and second.size
+
+
+def test_being_is_constructible_and_renders():
+    being = music.Being()
+    assert being is not None
+
+
+# --------------------------------------------------------------------------
+# The demonstration piece
+# --------------------------------------------------------------------------
+
+def test_test_song_2_renders(tmp_path, monkeypatch):
+    """Regression: `synth = M.legacy.CanonicalSynth` bound the class rather
+    than an instance, so every call in this module was an unbound method
+    missing self and the piece could not run at all. It writes its WAV
+    files to the working directory, so it is run inside tmp_path.
+    """
+    from music.legacy.pieces.testSong2 import TestSong2
+
+    monkeypatch.chdir(tmp_path)
+    song = TestSong2()
+
+    assert song.notes_, "the piece built no notes"
+    song.render()
+    assert (tmp_path / "vibrosong.wav").is_file()
+    assert len(list(tmp_path.glob("*.wav"))) > 1
+
+
+def test_the_module_level_synth_is_an_instance():
+    """The bug above in one assertion, without rendering anything."""
+    from music.legacy.pieces import testSong2
+
+    assert isinstance(testSong2.synth, CanonicalSynth)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -206,3 +206,56 @@ def test_absent_sonic_vector_still_yields_a_bare_envelope(name):
     omitted = np.asarray(function())
     assert np.asarray(function(sonic_vector=0)).shape == omitted.shape
     assert np.asarray(function(sonic_vector=None)).shape == omitted.shape
+
+
+# --------------------------------------------------------------------------
+# Non-default branches
+# --------------------------------------------------------------------------
+
+# The sweep above calls each export with its documented defaults, which left
+# whole branches untested: the mono path of a function that defaults to
+# stereo, and the alternative of a `method` parameter. Each of the cases
+# below was broken.
+
+@pytest.mark.parametrize("stereo", [True, False])
+def test_note_with_vibrato_seq_localization_renders_both_channel_modes(
+        stereo):
+    """Regression: the mono branch raised AttributeError, having assigned a
+    per-segment value over the accumulator it then appended to. Two further
+    faults sat behind it -- the `durations` parameter clobbered by a local,
+    and `extend` where the stereo branch appends."""
+    out = music.note_with_vibrato_seq_localization(stereo=stereo)
+    assert out.ndim == (2 if stereo else 1)
+    assert np.isfinite(out).all()
+    assert out.size > 0
+
+
+@pytest.mark.parametrize("method", ["ifft", "brute"])
+def test_localize2_supports_both_documented_methods(method):
+    """Regression: 'brute' computed its buffer size as a float and np.zeros
+    refused it."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = music.localize2(method=method)
+    assert out.shape[0] == 2
+    assert np.isfinite(out).all()
+
+
+def test_localize2_rejects_an_unknown_method():
+    with pytest.raises(ValueError, match="only methods implemented"):
+        music.localize2(method="telepathy")
+
+
+@pytest.mark.parametrize("stereo", [True, False])
+def test_note_with_doppler_renders_both_channel_modes(stereo):
+    out = music.note_with_doppler(stereo=stereo, number_of_samples=2000)
+    assert out.ndim == (2 if stereo else 1)
+    assert np.isfinite(out).all()
+
+
+def test_noise_accepts_a_numeric_gain_per_octave():
+    """The docstring documents ntype=3.5 as 3.5 dB per octave."""
+    np.random.seed(0)
+    out = music.noise(3.5, duration=0.5)
+    assert out.size > 0
+    assert np.isfinite(out).all()


### PR DESCRIPTION
`mypy music` had been reporting success while inspecting **about a sixth of the
code**. Most of this package is unannotated, and mypy skips the bodies of
unannotated functions by default. Turning on `check_untyped_defs` surfaced
**177 errors**.

They were not noise. **Three exported code paths had never run.**

## 1. The mono branch of `note_with_vibrato_seq_localization`

Three faults, one behind the other — each only visible once the one in front
was fixed:

| # | Fault | Effect |
|---|---|---|
| 1 | `f_ = speed / (speed + vs)` assigned a per-segment value over the accumulator, then `f_.append(f_)` | `AttributeError: 'numpy.ndarray' object has no attribute 'append'` |
| 2 | a local named `durations` clobbered the parameter | next iteration indexed into an array — `IndexError` |
| 3 | `v_.extend(f_)` where the stereo branch appends | spread 600k scalars into the list, `np.prod` got an inhomogeneous array |

Every fix is modelled on the **working stereo branch immediately beside it**,
which uses `dl`/`dr` for distances, `fl`/`fr` for per-segment values, and
`v_ + [f_[0]]` to add one contribution. The mono branch was the same code with
the temporaries collapsed onto the names they were supposed to feed.

## 2. `localize2(method="brute")`

The documented alternative to `"ifft"` computed its buffer size as a float,
and `np.zeros` refuses one. It had never worked.

## 3. `music.legacy.pieces.testSong2`

All **108** of its errors were one root cause: `synth = M.legacy.CanonicalSynth`
bound the **class**, not an instance, so every call in the module was an unbound
method missing `self`. The piece could not run at all. It now does — one line.

Also: `CanonicalSynth.adsrApply` gave the sustain stage a negative length on
notes shorter than attack + decay + release, the same fault fixed earlier in
`music.adsr`.

## Removing the `exec`

Three `exec("self.{}={}".format(i, i))` calls copied local variables onto the
instance. They are now `vars(self).update(...)`, and the attributes
`CanonicalSynth`, `Being` and `TestSong2` end up with are declared at class
level.

That is *why* they were invisible to mypy — but the declarations earn their
keep independently: `Being`'s surface is set from **outside** the class (the
examples assign `being.perms`, `being.domain`, `being.curseq` before rendering),
and nothing said so anywhere.

The remainder were mechanical — list accumulators rebound to arrays (renamed, so
each name has one role), missing annotations on empty lists, and attributes
initialised to `None` that mypy could not narrow.

## Why the earlier sweep missed all this

`tests/test_public_api.py` calls every export **with its documented defaults**.
`note_with_vibrato_seq_localization` defaults to `stereo=True`; `localize2`
defaults to `method="ifft"`. The sweep passed while the alternatives were
broken. It now exercises both channel modes and both methods.

## Coverage

| | before | after |
|---|---|---|
| `CanonicalSynth` | 11% | **97%** |
| `IteratorSynth` | 25% | **100%** |
| `testSong2` | 0% | **100%** |
| Overall | 70% | **84%** |
| Tests | 195 | **205** |

`tests/test_legacy.py` pins the attribute surface, the defaults and the
rendering, so the dynamic assignment cannot drift unnoticed.

Floor raised 65% → 80%. **`check_untyped_defs` is now on in `pyproject.toml`**,
so plain `mypy music` runs the real check and CI enforces it.

## Verification

Clean clone, `pip install -e '.[dev,docs]'`, `MUSIC_ECANTORIX_DIR` pointing
nowhere: ruff clean, mypy clean, 205 tests, docs build with `-W`. 9 of 10
examples run clean, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
