### PR TITLE
Build the waveform tables once, from the waveform they name

### DIFF
--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -298,8 +298,10 @@ Ordered by return on effort. Phase 1 is roughly a day and removes every "Terribl
 14. **Replace all 16 `type(x) in (np.ndarray, list)` checks** with
     `sonic_vector is not None` plus `np.asarray()`, and change the sentinel defaults from `0`
     to `None`. This eliminates a whole class of silent-wrong-answer bugs.
-15. **Collapse the three waveform-table implementations to one** (`utils.WAVEFORM_*` is the
-    canonical set); have `PrimaryTables` and `legacy/tables.py` delegate to it.
+15. **Collapse the three waveform-table implementations to one.** *(Done — though not as
+    sketched here. `utils.WAVEFORM_*` turned out to be the *wrong* set: measured against the
+    continuous waveforms, its triangle and the sawtooth in all three copies were the drifted
+    ones. All three now delegate to `music.utils.waveform_table`, which is exact.)*
 16. **Move the module-level RNG defaults into the function bodies** (`if sonic_vector is None:
     ...`) and drop 2.4 MB and the import cost.
 17. **Remove `exec` from `CanonicalSynth`** — explicit attribute assignment restores ~40 type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Needs a decision before release
-Three entries below change behaviour that callers may depend on. All are
+Four entries below change behaviour that callers may depend on. All are
 deliberate, all are tracked, and none should reach a release unreviewed.
 
 1. **`localize_linear()` is no longer exported** and raises
@@ -21,13 +21,32 @@ deliberate, all are tracked, and none should reach a release unreviewed.
    nothing. Anyone who was relying on the shorter peal can ask for it with
    `nhunts=2`; anyone rendering from `peal_direct` at six bells or more will
    get six times the material or more.
-3. **The WAV quantiser's scale changed**, so files written from now on differ
+3. **The waveform tables are now exact**, so every rendered note changes
+   slightly. Two of the four were built by halves and drifted from the
+   waveform they name: the sawtooth stepped by `2/(size-1)` instead of
+   `2/size`, and `WAVEFORM_TRIANGULAR` -- the default table for every note
+   this package synthesizes -- had a flat two-sample top that peaked at
+   `1 - 2/size` rather than 1. Measured against the continuous waveform
+   sampled at the same phases, the errors were 1.2e-4 and 2.4e-4; both are
+   now zero. A 440 Hz note changes by at most 2.4e-4 (-72 dBFS, inaudible)
+   but half its samples differ, so byte comparisons against earlier renders
+   will not match.
+4. **The WAV quantiser's scale changed**, so files written from now on differ
    from files written before by one LSB of gain (about 0.0003 dB — inaudible,
    but the bytes differ). This is what makes a write/read round trip unity
    gain, and `tests/test_fidelity.py` now pins that property. Anyone
    byte-comparing against previously rendered WAVs will see a diff.
 
 ### Fixed
+- The waveform lookup tables were three separate implementations of the same
+  four definitions -- in `utils`, in `tables.PrimaryTables` and in
+  `legacy.tables.Basic` -- and they had drifted: the first built its triangle
+  as `hstack((t, t[::-1]))` and the other two as `hstack((t, -t))`, which
+  differ at the peak sample. All three now come from
+  `music.utils.waveform_table`, and `legacy.tables.Basic` is
+  `PrimaryTables` under its historical name.
+- Asking `PrimaryTables` for an odd `size` returned tables one sample short,
+  the two built from halves having summed to `size - 1`.
 - The mono branch of `note_with_vibrato_seq_localization()` had never run.
   Three faults, one behind the other: a per-segment value was assigned over
   the accumulator that the next line appended to, raising `AttributeError`;
@@ -164,6 +183,11 @@ deliberate, all are tracked, and none should reach a release unreviewed.
 - `music/singing/paths.py`, a single source of truth for where the engine
   lives and what it needs. The path was previously computed twice, in
   `bootstrap.py` and in `perform.py`, both at import time.
+- `music.utils.waveform_table(kind, size)`, the single generator the tables
+  now come from. Each waveform is written directly as a function of phase,
+  which is exact at any size, and `tests/test_fidelity.py` asserts that
+  against the continuous waveform rather than against whatever the code
+  happens to emit.
 - `tests/test_legacy.py`, covering the legacy synthesizers, which were the
   least-tested modules in the package. `CanonicalSynth` went from 11% to 97%,
   `IteratorSynth` from 25% to 100% and `testSong2` from 0% to 100%.

--- a/music/legacy/tables.py
+++ b/music/legacy/tables.py
@@ -1,52 +1,23 @@
 """Legacy lookup tables for common waveforms."""
 
-import numpy as np
-import pylab as plt
+from ..tables import PrimaryTables
 
 
-class Basic:
+class Basic(PrimaryTables):
+    """Primary waveform tables, under the name the legacy synthesizers use.
+
+    This was a third copy of the same four table definitions. It is now
+    :class:`music.tables.PrimaryTables` under its historical name, so
+    `CanonicalSynth` and anything else reaching for
+    ``music.legacy.tables.Basic`` keeps working.
+
+    Parameters
+    ----------
+    size : int, optional
+        The number of samples for each waveform table, by default 2048.
+
+    See Also
+    --------
+    music.tables.PrimaryTables : the class this is an alias for.
+    music.utils.waveform_table : builds one table.
     """
-    Provides primary tables for lookup, including sine, triangle, square, and
-    saw wave periods.
-    """
-
-    def __init__(self, size=2048):
-        """
-        Initializes a Basic object.
-
-        Parameters
-        ----------
-        size : int, optional
-            The size of the tables. Defaults to 2048.
-
-        """
-        self.size = size
-        self.make_tables(size)
-
-    def make_tables(self, size):
-        """
-        Creates sine, triangle, square, and saw wave periods.
-
-        Parameters
-        ----------
-        size : int
-            The size of the tables.
-
-        """
-        self.sine = np.sin(np.linspace(0, 2 * np.pi, size, endpoint=False))
-        self.saw = np.linspace(-1, 1, size)
-        self.square = np.hstack((np.ones(size // 2) * -1, np.ones(size // 2)))
-        foo = np.linspace(-1, 1, size // 2, endpoint=False)
-        self.triangle = np.hstack((foo, foo * -1))
-
-    def draw_tables(self):
-        """
-        Plots the sine, triangle, square, and saw wave periods.
-        """
-        plt.plot(self.sine, "-o")
-        plt.plot(self.saw, "-o")
-        plt.plot(self.square, "-o")
-        plt.plot(self.triangle, "-o")
-        plt.xlim(-self.size * 0.1, self.size * 1.1)
-        plt.ylim(-1.1, 1.1)
-        plt.show()

--- a/music/tables.py
+++ b/music/tables.py
@@ -18,8 +18,9 @@ Classes in this module:
 
 * ``PrimaryTables`` -- provides primary tables for waveform lookup.
 """
-import numpy as np
 import pylab as p
+
+from .utils import waveform_table
 
 
 class PrimaryTables:
@@ -74,11 +75,10 @@ class PrimaryTables:
         size : int
             The number of samples for each waveform table.
         """
-        self.sine = np.sin(np.linspace(0, 2 * np.pi, size, endpoint=False))
-        self.saw = np.linspace(-1, 1, size)
-        self.square = np.hstack((np.ones(size // 2) * -1, np.ones(size // 2)))
-        foo = np.linspace(-1, 1, size // 2, endpoint=False)
-        self.triangle = np.hstack((foo, foo * -1))
+        self.sine = waveform_table("sine", size)
+        self.saw = waveform_table("sawtooth", size)
+        self.square = waveform_table("square", size)
+        self.triangle = waveform_table("triangle", size)
 
     def draw_tables(self):
         """Draw waveform tables."""

--- a/music/utils.py
+++ b/music/utils.py
@@ -8,12 +8,66 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 LAMBDA_TILDE = 1024 * 16
-WAVEFORM_SINE = np.sin(np.linspace(0, 2 * np.pi, LAMBDA_TILDE, endpoint=False))
-WAVEFORM_SAWTOOTH = np.linspace(-1, 1, LAMBDA_TILDE)
-WAVEFORM_SQUARE = np.hstack((np.ones(int(LAMBDA_TILDE / 2)) * -1,
-                             np.ones(int(LAMBDA_TILDE / 2))))
-triangular_tmp = np.linspace(-1, 1, LAMBDA_TILDE // 2, endpoint=False)
-WAVEFORM_TRIANGULAR = np.hstack((triangular_tmp, triangular_tmp[::-1]))
+
+#: The waveforms :func:`waveform_table` knows how to build.
+WAVEFORMS = ("sine", "sawtooth", "square", "triangle")
+
+
+def waveform_table(kind: str,
+                   size: int = LAMBDA_TILDE) -> NDArray[np.float64]:
+    """One period of a primary waveform, as a lookup table.
+
+    Each table is written directly as a function of the phase, so it is
+    exact at any size and holds exactly `size` samples. Building them by
+    halves instead — the way this package used to — costs a sample at odd
+    sizes and puts the sawtooth and triangle slightly out of true.
+
+    Parameters
+    ----------
+    kind : {'sine', 'sawtooth', 'square', 'triangle'}
+        Which waveform to build.
+    size : int, optional
+        The number of samples in the period. Defaults to LAMBDA_TILDE.
+
+    Returns
+    -------
+    ndarray
+        `size` samples spanning one period, in [-1, 1].
+
+    Raises
+    ------
+    ValueError
+        If `kind` is not one of WAVEFORMS, or `size` is not positive.
+
+    Examples
+    --------
+    >>> waveform_table('square', 4)
+    array([-1., -1.,  1.,  1.])
+    >>> waveform_table('triangle', 4)
+    array([-1.,  0.,  1.,  0.])
+    >>> waveform_table('sawtooth', 4)
+    array([-1. , -0.5,  0. ,  0.5])
+    """
+    if size <= 0:
+        raise ValueError(f"size must be positive; got {size}")
+    phase = np.arange(size) / size
+    if kind == "sine":
+        return np.sin(2 * np.pi * phase)
+    if kind == "sawtooth":
+        return 2 * phase - 1
+    if kind == "square":
+        return np.where(phase < .5, -1.0, 1.0)
+    if kind == "triangle":
+        return np.where(phase <= .5, -1 + 4 * phase, 3 - 4 * phase)
+    raise ValueError(
+        f"unknown waveform {kind!r}; expected one of {list(WAVEFORMS)}"
+    )
+
+
+WAVEFORM_SINE = waveform_table("sine")
+WAVEFORM_SAWTOOTH = waveform_table("sawtooth")
+WAVEFORM_SQUARE = waveform_table("square")
+WAVEFORM_TRIANGULAR = waveform_table("triangle")
 
 
 def as_sonic_vector(sonic_vector: Any) -> NDArray[np.float64] | None:

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -1,19 +1,7 @@
-import importlib.util
-from pathlib import Path
 import numpy as np
 
-HERE = Path(__file__).resolve().parents[1]
-
-
-def load_module(name, relative_path):
-    path = HERE / relative_path
-    spec = importlib.util.spec_from_file_location(name, path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-utils = load_module('utils', 'music/utils.py')
-permutations = load_module('permutations', 'music/structures/permutations.py')
+from music import utils
+from music.structures import permutations
 
 
 def test_midi_interval_and_pitch_to_freq():

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -16,7 +16,11 @@ import pytest
 
 import music
 from music.core.functions import normalize_mono
-from music.utils import WAVEFORM_SINE, WAVEFORM_TRIANGULAR
+from music.legacy.tables import Basic
+from music.tables import PrimaryTables
+from music.utils import (WAVEFORMS, WAVEFORM_SAWTOOTH, WAVEFORM_SINE,
+                         WAVEFORM_SQUARE, WAVEFORM_TRIANGULAR,
+                         waveform_table)
 
 SAMPLE_RATE = 44100
 
@@ -237,3 +241,81 @@ def test_stereo_wav_round_trip_preserves_channel_balance(tmp_path):
 
     ratio = np.abs(restored[0]).max() / np.abs(restored[1]).max()
     assert ratio == pytest.approx(2.0, rel=0.01)
+
+
+# --------------------------------------------------------------------------
+# Waveform lookup tables
+# --------------------------------------------------------------------------
+
+def _ideal(kind, size):
+    """The continuous waveform sampled at phase k / size."""
+    phase = np.arange(size) / size
+    return {
+        "sine": np.sin(2 * np.pi * phase),
+        "sawtooth": 2 * phase - 1,
+        "square": np.where(phase < .5, -1.0, 1.0),
+        "triangle": np.where(phase <= .5, -1 + 4 * phase, 3 - 4 * phase),
+    }[kind]
+
+
+@pytest.mark.parametrize("kind", WAVEFORMS)
+@pytest.mark.parametrize("size", [4, 16, 15, 2048, 2049, 16384])
+def test_waveform_table_is_exact_at_any_size(kind, size):
+    """Each table must equal the continuous waveform sampled at its phase.
+
+    Regression: the tables were built by halves. That made the sawtooth
+    step 2/(size-1) instead of 2/size, gave the triangle a flat two-sample
+    top that never reached full amplitude, and returned one sample fewer
+    than asked for at odd sizes.
+    """
+    table = waveform_table(kind, size)
+
+    assert len(table) == size
+    assert np.allclose(table, _ideal(kind, size), atol=1e-15)
+    assert table.min() >= -1.0 and table.max() <= 1.0
+
+
+@pytest.mark.parametrize("kind", WAVEFORMS)
+def test_waveform_table_starts_at_the_bottom_of_its_period(kind):
+    """Every table opens at phase zero, which is -1 for all but the sine."""
+    table = waveform_table(kind, 1024)
+    expected = 0.0 if kind == "sine" else -1.0
+    assert table[0] == pytest.approx(expected, abs=1e-15)
+
+
+def test_triangle_reaches_full_amplitude_at_its_midpoint():
+    """Regression: the old triangle peaked at 1 - 2/size, never at 1."""
+    size = 1024
+    table = waveform_table("triangle", size)
+    assert table[size // 2] == pytest.approx(1.0, abs=1e-15)
+    assert table.max() == pytest.approx(1.0, abs=1e-15)
+
+
+def test_sawtooth_ramps_by_exactly_one_period_per_table():
+    """Consecutive samples rise by 2/size, so one period spans the table."""
+    size = 1024
+    table = waveform_table("sawtooth", size)
+    assert np.allclose(np.diff(table), 2 / size)
+
+
+def test_every_table_source_agrees():
+    """Regression: three separate implementations of the same four tables
+    had drifted apart at the triangle's peak sample."""
+    size = len(WAVEFORM_TRIANGULAR)
+    tables = PrimaryTables(size=size)
+    legacy = Basic(size=size)
+
+    assert np.array_equal(tables.sine, WAVEFORM_SINE)
+    assert np.array_equal(tables.saw, WAVEFORM_SAWTOOTH)
+    assert np.array_equal(tables.square, WAVEFORM_SQUARE)
+    assert np.array_equal(tables.triangle, WAVEFORM_TRIANGULAR)
+
+    for name in ("sine", "saw", "square", "triangle"):
+        assert np.array_equal(getattr(legacy, name), getattr(tables, name))
+
+
+def test_waveform_table_rejects_nonsense():
+    with pytest.raises(ValueError, match="unknown waveform"):
+        waveform_table("ocarina")
+    with pytest.raises(ValueError, match="size must be positive"):
+        waveform_table("sine", 0)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,22 +1,14 @@
-import importlib.util
-from pathlib import Path
+"""The primary waveform lookup tables."""
+
 import numpy as np
+import pytest
 
-HERE = Path(__file__).resolve().parents[1]
-
-
-def load_module(name, relative_path):
-    path = HERE / relative_path
-    spec = importlib.util.spec_from_file_location(name, path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-tables = load_module('tables', 'music/tables.py')
+from music.tables import PrimaryTables
+from music.utils import WAVEFORMS, waveform_table
 
 
 def test_primary_tables_shapes():
-    pt = tables.PrimaryTables(size=16)
+    pt = PrimaryTables(size=16)
     assert pt.sine.shape == (16,)
     assert pt.triangle.shape == (16,)
     assert pt.square.shape == (16,)
@@ -24,3 +16,23 @@ def test_primary_tables_shapes():
     # sine first element is 0 and last is close to -step
     assert np.isclose(pt.sine[0], 0.0)
 
+
+def test_primary_tables_records_its_size():
+    assert PrimaryTables(size=64).size == 64
+
+
+@pytest.mark.parametrize("size", [4, 15, 16, 2048, 2049])
+def test_primary_tables_holds_exactly_the_size_requested(size):
+    """Regression: built by halves, the square and triangle came back one
+    sample short whenever size was odd."""
+    pt = PrimaryTables(size=size)
+    for name in ("sine", "saw", "square", "triangle"):
+        assert len(getattr(pt, name)) == size, name
+
+
+@pytest.mark.parametrize("kind, attribute", list(zip(
+    WAVEFORMS, ("sine", "saw", "square", "triangle"))))
+def test_primary_tables_delegates_to_the_one_generator(kind, attribute):
+    """There used to be three copies of these four definitions."""
+    pt = PrimaryTables(size=256)
+    assert np.array_equal(getattr(pt, attribute), waveform_table(kind, 256))


### PR DESCRIPTION
The four primary waveform lookup tables had **three separate
implementations** — in `utils`, in `tables.PrimaryTables`, and in
`legacy.tables.Basic` — and they had drifted apart at the triangle's peak
sample. `utils` built it as `hstack((t, t[::-1]))`, the other two as
`hstack((t, -t))`.

## Deciding which to keep meant asking which is *right*

So I measured both against the continuous triangle sampled at the same phases.
At 16 samples the difference is plain:

```
ideal   ... 0.75,  1.0,  0.75,  0.5,  0.25,  0.0, -0.25, ...
utils   ... 0.75,  0.75, 0.5,   0.25, 0.0,  -0.25, -0.5, ... , -1.0
tables  ... 0.75,  1.0,  0.75,  0.5,  0.25, -0.0, -0.25, ...
```

**`utils` is the drifted one** — a flat two-sample top peaking at
`1 - 2/size` instead of 1, and half a sample out of phase on the falling
side. That is the default table for *every note this package synthesizes*.

Checking the other three the same way found the **sawtooth wrong in all three
copies**: `linspace(-1, 1, size)` steps by `2/(size-1)`, not `2/size`. Sine and
square were already exact.

| table | max error vs. ideal, before | after |
|---|---|---|
| sine | 0 | 0 |
| square | 0 | 0 |
| sawtooth | 1.2 × 10⁻⁴ | **0** |
| triangle (`utils`) | 2.4 × 10⁻⁴ | **0** |

## One implementation, written as the waveform it names

```python
phase    = np.arange(size) / size
sine     = np.sin(2 * np.pi * phase)
sawtooth = 2 * phase - 1
square   = np.where(phase < .5, -1.0, 1.0)
triangle = np.where(phase <= .5, -1 + 4 * phase, 3 - 4 * phase)
```

This is **bit-identical** to the current sine, square and `PrimaryTables`
triangle — verified at several sizes — so those change not at all, and it fixes
the other two. It also fixes **odd sizes**, where summing two halves of
`size // 2` returned a table one sample short of what was asked for.

`music.utils.waveform_table(kind, size)` is now the only implementation.
`PrimaryTables` delegates to it, and `legacy.tables.Basic` is `PrimaryTables`
under its historical name, so `CanonicalSynth` keeps working.

## ⚠️ A behaviour change that needs your decision

Listed in `CHANGELOG.md` under **"Needs a decision before release"**, with the
three already there.

A 440 Hz note changes by at most **2.4 × 10⁻⁴ (−72 dBFS)** — inaudible — but
**half its samples differ**, so byte comparisons against earlier renders will
not match. My recommendation is to keep it: an extreme-fidelity package should
not ship a default waveform that never reaches full amplitude.

## Tests

`tests/test_fidelity.py` now asserts each table against the **continuous
waveform**, not against whatever the code emits — which is what made the drift
visible in the first place. Sizes 4, 15, 16, 2048, 2049 and 16384, so the
odd-size case is covered too.

## Also

Removes the last two `spec_from_file_location` hacks from the tests, which
`conftest.py` replaced everywhere else. `test_tables.py` loaded
`music/tables.py` **by path** and broke the moment that module gained a
relative import — which is how I found it.

247 tests, 84% coverage.

## Verification

Clean clone, `pip install -e '.[dev,docs]'`, `MUSIC_ECANTORIX_DIR` pointing
nowhere: ruff clean, mypy clean on 3.10 / 3.11 / 3.12, 247 tests, docs build
with `-W`. 9 of 10 examples run clean, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
