### PR TITLE
Make fir() apply the frequency response it is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Needs a decision before release
-Four entries below change behaviour that callers may depend on. All are
+Five entries below change behaviour that callers may depend on. All are
 deliberate, all are tracked, and none should reach a release unreviewed.
 
 1. **`localize_linear()` is no longer exported** and raises
@@ -31,13 +31,30 @@ deliberate, all are tracked, and none should reach a release unreviewed.
    now zero. A 440 Hz note changes by at most 2.4e-4 (-72 dBFS, inaudible)
    but half its samples differ, so byte comparisons against earlier renders
    will not match.
-4. **The WAV quantiser's scale changed**, so files written from now on differ
+4. **`fir()` now applies the magnitude response it is given**, which changes
+   its output substantially for anyone using the default `freq=True`. The old
+   behaviour was a boxcar average scaled by the response rather than the
+   response itself; there is no sense in which it was the intended filter, so
+   this is listed for visibility rather than as a judgement call.
+5. **The WAV quantiser's scale changed**, so files written from now on differ
    from files written before by one LSB of gain (about 0.0003 dB — inaudible,
    but the bytes differ). This is what makes a write/read round trip unity
    gain, and `tests/test_fidelity.py` now pins that property. Anyone
    byte-comparing against previously rendered WAVs will see a diff.
 
 ### Fixed
+- `fir()` applied a magnitude response by convolving with the magnitudes
+  themselves rather than with their inverse transform, so it was not really
+  applying the response at all. The decisive case: a *flat* response, meaning
+  "pass every frequency unchanged", convolved the signal with a run of ones --
+  a boxcar moving average. It now transforms the zero-phase spectrum into an
+  impulse response first, so a flat response is the identity and a low-pass
+  is about a hundred times more selective than before. This is the default
+  path: `freq` defaults to True.
+- `iir()` raised `TypeError: can't multiply sequence by non-int` when given
+  the "iterable of scalars" its parameters are documented as taking. Only
+  numpy arrays worked. Its arithmetic was correct -- a one-pole matches its
+  closed form exactly -- so only the input handling changed.
 - The waveform lookup tables were three separate implementations of the same
   four definitions -- in `utils`, in `tables.PrimaryTables` and in
   `legacy.tables.Basic` -- and they had drifted: the first built its triangle
@@ -183,6 +200,11 @@ deliberate, all are tracked, and none should reach a release unreviewed.
 - `music/singing/paths.py`, a single source of truth for where the engine
   lives and what it needs. The path was previously computed twice, in
   `bootstrap.py` and in `perform.py`, both at import time.
+- `tests/test_filters_response.py`, testing what the FIR and IIR filters do
+  to a signal rather than that they return an array: a flat response is the
+  identity, a low-pass removes the high band, an impulse response convolves
+  as given, a one-pole matches `pole ** n`, and both filters are linear.
+  Coverage of `impulse_response.py` went from 14% to 100%.
 - `music.utils.waveform_table(kind, size)`, the single generator the tables
   now come from. Each waveform is written directly as a function of phase,
   which is exact at any size, and `tests/test_fidelity.py` asserts that

--- a/music/core/filters/impulse_response.py
+++ b/music/core/filters/impulse_response.py
@@ -25,20 +25,45 @@ def fir(samples, sonic_vector, freq=True, max_freq=True):
         Set to True if the last item in the samples is related to the Nyquist
         frequency fs / 2. Ignored if freq=False.
 
+    Returns
+    -------
+    ndarray
+        The filtered signal, of length len(sonic_vector) + len(kernel) - 1.
+        The kernel is symmetric, so the filter is linear phase and the
+        output is delayed by half the kernel.
+
     Notes
     -----
     If freq=True, the samples are the absolute values of the frequency
     components. The phases are set to zero to maintain the phases of the
     components of the original signal.
 
+    A magnitude response is applied by convolving with its inverse
+    transform, not with the magnitudes themselves. Convolving with them
+    directly -- which this did -- makes a flat response a boxcar average
+    rather than the identity it should be.
+
+    Examples
+    --------
+    >>> signal = np.arange(5.)
+    >>> flat = np.ones(5)  # pass every frequency unchanged
+    >>> filtered = fir(flat, signal)
+    >>> np.allclose(filtered[4:9], signal)
+    True
+
     """
+    samples = np.asarray(samples, dtype=np.float64)
+    sonic_vector = np.asarray(sonic_vector, dtype=np.float64)
     if not freq:
         return np.convolve(samples, sonic_vector)
     if max_freq:
-        s = np.hstack((samples, samples[1:-1][::-1]))
+        spectrum = np.hstack((samples, samples[1:-1][::-1]))
     else:
-        s = np.hstack((samples, samples[1:][::-1]))
-    return np.convolve(s, sonic_vector)
+        spectrum = np.hstack((samples, samples[1:][::-1]))
+    # Zero phase, so the transform is real and symmetric; fftshift centres
+    # it, which turns the wrap-around into a plain delay.
+    kernel = np.fft.fftshift(np.fft.ifft(spectrum).real)
+    return np.convolve(kernel, sonic_vector)
 
 
 def iir(sonic_vector, a, b):
@@ -67,14 +92,19 @@ def iir(sonic_vector, a, b):
            representation of sound." arXiv preprint arXiv:abs/1412.6853 (2017)
 
     """
-    signal = sonic_vector
+    # asarray so the "iterable of scalars" the parameters document really
+    # works: two Python lists multiplied together is a TypeError, not an
+    # elementwise product.
+    signal = np.asarray(sonic_vector, dtype=np.float64)
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
     signal_: list = []
     for i in range(len(signal)):
         samples_a = signal[i::-1][:len(a)]
         a_coeffs = a[:i + 1]
         a_contrib = (samples_a * a_coeffs).sum()
 
-        samples_b = signal_[-1:-1 - i:-1][:len(b) - 1]
+        samples_b = np.asarray(signal_[-1:-1 - i:-1][:len(b) - 1])
         b_coeffs = b[1:i + 1]
         b_contrib = (samples_b * b_coeffs).sum()
         t_i = (a_contrib + b_contrib) / b[0]

--- a/tests/test_filters_response.py
+++ b/tests/test_filters_response.py
@@ -1,0 +1,134 @@
+"""What the FIR and IIR filters must do to a signal.
+
+These were the least-covered modules in the package at 14%, and both had
+defects that only a test of the filtering itself would catch: `fir` applied
+a magnitude response by convolving with the magnitudes rather than with
+their inverse transform, so a *flat* response low-passed the signal instead
+of leaving it alone.
+"""
+
+import numpy as np
+import pytest
+
+import music
+
+SAMPLE_RATE = 44100
+
+
+def _band_energy(signal, low, high, sample_rate=SAMPLE_RATE):
+    freqs = np.fft.rfftfreq(len(signal), 1 / sample_rate)
+    spectrum = np.abs(np.fft.rfft(signal))
+    return float((spectrum[(freqs >= low) & (freqs < high)] ** 2).sum())
+
+
+def _noise(length=4096, seed=0):
+    rng = np.random.default_rng(seed)
+    return rng.uniform(-1, 1, length)
+
+
+# --------------------------------------------------------------------------
+# fir
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("max_freq", [True, False])
+def test_a_flat_magnitude_response_leaves_the_signal_alone(max_freq):
+    """Regression: this convolved with the magnitudes themselves, so a flat
+    response was a boxcar moving average rather than the identity."""
+    signal = _noise(512)
+    flat = np.ones(33)
+
+    filtered = music.fir(flat, signal, freq=True, max_freq=max_freq)
+
+    kernel_length = len(np.hstack(
+        (flat, flat[1:-1][::-1] if max_freq else flat[1:][::-1])
+    ))
+    delay = kernel_length // 2
+    assert np.allclose(filtered[delay:delay + len(signal)], signal)
+
+
+def test_a_low_pass_magnitude_response_removes_the_high_band():
+    """A response that passes only the lowest quarter must do so sharply."""
+    signal = _noise(8192)
+    magnitudes = np.zeros(65)
+    magnitudes[:16] = 1.0
+
+    filtered = music.fir(magnitudes, signal, freq=True)
+
+    before = (_band_energy(signal, 0, 5000)
+              / _band_energy(signal, 15000, 22050))
+    after = (_band_energy(filtered, 0, 5000)
+             / _band_energy(filtered, 15000, 22050))
+    assert after > 100 * before
+
+
+def test_an_impulse_response_is_convolved_as_given():
+    """With freq=False the samples are the kernel, untransformed."""
+    signal = _noise(64)
+    delay_by_one = np.array([0.0, 1.0, 0.0])
+
+    filtered = music.fir(delay_by_one, signal, freq=False)
+
+    assert np.allclose(filtered[1:len(signal) + 1], signal)
+
+
+def test_fir_is_linear():
+    """Filtering is linear: it distributes over a weighted sum."""
+    first, second = _noise(256, seed=1), _noise(256, seed=2)
+    magnitudes = np.linspace(1, 0, 17)
+
+    together = music.fir(magnitudes, 2 * first - 3 * second)
+    apart = (2 * music.fir(magnitudes, first)
+             - 3 * music.fir(magnitudes, second))
+    assert np.allclose(together, apart)
+
+
+def test_fir_accepts_lists():
+    """The parameters are documented as array_like."""
+    out = music.fir([1.0, 1.0, 1.0], [0.0, 1.0, 0.0, 0.0])
+    assert np.isfinite(out).all()
+
+
+# --------------------------------------------------------------------------
+# iir
+# --------------------------------------------------------------------------
+
+def test_iir_identity_passes_the_signal_through():
+    signal = np.array([1.0, 2.0, 3.0, 4.0])
+    assert np.allclose(music.iir(signal, [1.0], [1.0]), signal)
+
+
+@pytest.mark.parametrize("pole", [0.5, 0.9, -0.5])
+def test_iir_one_pole_matches_its_closed_form(pole):
+    """y[n] = x[n] + pole * y[n-1], driven by an impulse, is pole ** n."""
+    impulse = np.zeros(16)
+    impulse[0] = 1.0
+
+    out = music.iir(impulse, [1.0], [1.0, pole])
+
+    assert np.allclose(out, pole ** np.arange(16))
+
+
+def test_iir_feedforward_matches_a_convolution():
+    """With no feedback the filter is an ordinary FIR convolution."""
+    signal = _noise(64)
+    taps = [0.5, 0.25, 0.125]
+
+    out = music.iir(signal, taps, [1.0])
+
+    assert np.allclose(out, np.convolve(signal, taps)[:len(signal)])
+
+
+def test_iir_accepts_lists_as_documented():
+    """Regression: the coefficients are documented as an iterable of
+    scalars, but two Python lists multiplied together raise TypeError."""
+    out = music.iir([1.0, 0.0, 0.0, 0.0], [1.0], [1.0, 0.5])
+    assert np.allclose(out, [1.0, 0.5, 0.25, 0.125])
+
+
+def test_iir_is_linear():
+    first, second = _noise(128, seed=3), _noise(128, seed=4)
+    a, b = [1.0, 0.3], [1.0, -0.4]
+
+    together = music.iir(2 * first - 3 * second, a, b)
+    apart = 2 * music.iir(first, a, b) - 3 * music.iir(second, a, b)
+    assert np.allclose(together, apart)


### PR DESCRIPTION
`impulse_response.py` was the least-covered module left at **14%**, and both of
its functions had defects that only a test of the *filtering* would find.

## `fir()` was not applying the response it was given

It built the mirrored zero-phase spectrum — that part is right — and then
convolved the signal with **the magnitudes themselves**. The inverse transform
that turns a spectrum into an impulse response was missing. Convolving with a
spectrum is not filtering by it.

**The decisive case is a flat response.** All ones means "pass every frequency
unchanged". That convolved the signal with a run of ones — a boxcar moving
average. A response that should do nothing low-passed the signal instead:

```
input   0.0976   0.4304   0.2055   0.0898  -0.1527
before  0.0976   0.5280   0.7335   0.8233   0.6706     ← smeared
after   0.0976   0.4304   0.2055   0.0898  -0.1527     ← unchanged
```

It was easy to miss because the *direction* was not wrong, only crude. On a
low-pass magnitude the old code did attenuate the high band — by a factor of
about 120. Transforming first gives about **29,000**.

This is the default path: `freq` defaults to `True`.

## `iir()` rejected its own documented input type

```
TypeError: can't multiply sequence by non-int of type 'list'
```

The coefficients are documented as "iterable of scalars", but two Python lists
multiplied together is not an elementwise product, so only numpy arrays worked.

Its **arithmetic was already correct** — a one-pole reproduces `pole ** n`
exactly, and with no feedback it matches `np.convolve`. Only the input handling
changed.

## Tests that assert filtering, not shape

`tests/test_filters_response.py`:

- a flat response is the **identity** (both `max_freq` settings)
- a low-pass response removes the high band, by >100× the input ratio
- an impulse response convolves **as given** when `freq=False`
- a one-pole matches its closed form `pole ** n`, for poles 0.5, 0.9 and −0.5
- feedforward-only `iir` matches `np.convolve`
- **both filters are linear** — they distribute over a weighted sum

| | before | after |
|---|---|---|
| `impulse_response.py` | 14% | **100%** |
| Overall | 84% | **85%** |
| Tests | 247 | **260** |

## Blast radius

Neither function is called anywhere inside the package or the examples — they
are public API only. `fir`'s change is listed in `CHANGELOG.md` under **"Needs
a decision before release"** for visibility, though there is no sense in which
the old behaviour was the intended filter, so it is not really a judgement
call.

## Verification

Clean clone, `pip install -e '.[dev,docs]'`, `MUSIC_ECANTORIX_DIR` pointing
nowhere: ruff clean, mypy clean, 260 tests, docs build with `-W`. 9 of 10
examples run clean, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
