### PR TITLE
Reach 100% coverage, and fix the ten defects that revealed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         run: mypy music
 
       - name: Test
-        run: pytest -q --cov=music --cov-report=term-missing --cov-fail-under=80
+        run: pytest -q --cov=music --cov-report=term-missing --cov-fail-under=100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,36 @@ deliberate, all are tracked, and none should reach a release unreviewed.
    byte-comparing against previously rendered WAVs will see a diff.
 
 ### Fixed
+- Nine defects that only appeared once every branch was exercised:
+  - `pan_transitions()` and `CanonicalSynth.tremoloEnvelope()` truth-tested
+    their `sonic_vector`, so passing one raised "the truth value of an array
+    with more than one element is ambiguous". Both had a correct
+    `is not None` check elsewhere in the same function.
+  - `mix_with_offset()`'s stereo path passed `['s1', 's2']` to
+    `resolve_stereo`, parameter names that had been renamed, and raised
+    `KeyError`.
+  - `mix_stereo()` tested for stereo with `len(x) != 2`, so a two-sample
+    mono vector was taken for a channel pair and its "channels" indexed as
+    scalars.
+  - `mix_with_offset_()` rejected tuples, via an exact
+    `type(a) not in (np.ndarray, list)` check.
+  - `localize2()` raised for every odd-length input: the conjugate mirror
+    ran to `max_coef`, which only balances when the length is even.
+  - `normalize_mono()` and `normalize_stereo()` returned NaN for any
+    constant signal. Only the all-zero case was guarded, and a constant is
+    silence once its offset is removed.
+  - `PlainChanges.peals` was never populated, so `act_all()` could not run
+    on the class that builds two peals.
+  - `Being.walk()` raised `UnboundLocalError` for an unrecognised method,
+    and `Being.setPar()` was a silent no-op for anything but 'f'.
+  - `CanonicalSynth.synthSetup()` left the vibrato and tremolo tables as
+    None when the effect was switched off, and both are read
+    unconditionally, so turning one off raised `TypeError`. A depth of zero
+    already makes the modulation a no-op.
+- An exponential position transition across the listener produced NaN audio:
+  `start * (end / start) ** curve` has a negative base when the source
+  changes sides, and a fractional power of that is not a real number. It now
+  raises, naming 'lin' as the method for a path that crosses.
 - `fir()` applied a magnitude response by convolving with the magnitudes
   themselves rather than with their inverse transform, so it was not really
   applying the response at all. The decisive case: a *flat* response, meaning
@@ -200,6 +230,12 @@ deliberate, all are tracked, and none should reach a release unreviewed.
 - `music/singing/paths.py`, a single source of truth for where the engine
   lives and what it needs. The path was previously computed twice, in
   `bootstrap.py` and in `perform.py`, both at import time.
+- Coverage is now 100%, enforced in CI. Reaching it is what surfaced the
+  defects listed above: `tests/test_mixing.py`, `test_normalization.py`,
+  `test_abc_notation.py`, `test_io_paths.py`, `test_branches.py` and
+  `test_remaining_paths.py` cover the alternative branches of parametrised
+  routines -- both channel modes, each `method`, each curve -- which is
+  where every one of them was hiding.
 - `tests/test_filters_response.py`, testing what the FIR and IIR filters do
   to a signal rather than that they return an array: a flat response is the
   identity, a low-pass removes the high band, an impulse response convolves

--- a/music/core/filters/localization.py
+++ b/music/core/filters/localization.py
@@ -338,7 +338,11 @@ def localize2(sonic_vector=None, theta=-70, x=.1, y=.01, zeta=0.215,
             # IID > 0 : left ear has amplification
             # ITD > 0 : right ear has a delay
             itd_l = abs(int(sample_rate * itd))
-            if i == lambda_l / 2:
+            # The Nyquist bin is not doubled, having no conjugate partner.
+            # Unreachable as written: the loop runs to ncoeffs - 1, and
+            # ncoeffs <= max_coef == int(lambda_l / 2), so i never reaches
+            # lambda_l / 2. Kept in case that bound is ever widened.
+            if i == lambda_l / 2:  # pragma: no cover
                 amplitude = norms[i] / lambda_l
             else:
                 amplitude = 2 * norms[i] / lambda_l
@@ -368,15 +372,21 @@ def localize2(sonic_vector=None, theta=-70, x=.1, y=.01, zeta=0.215,
             s += s_
     if method == "ifft":
         coefsl = normsl * np.e ** (anglesl * 1j)
+        # The conjugate mirror runs to lambda_l - max_coef, not max_coef:
+        # for an odd length those differ and the assignment did not fit.
+        mirror = slice(1, lambda_l - max_coef)
         coefsl[max_coef + 1:] = np.real(
-                coefsl[1:max_coef])[::-1] - 1j * np.imag(
-                        coefsl[1:max_coef])[::-1]
+                coefsl[mirror])[::-1] - 1j * np.imag(
+                        coefsl[mirror])[::-1]
         sl = np.fft.ifft(coefsl).real
 
         coefsr = normsr * np.e ** (anglesr * 1j)
+        # The conjugate mirror runs to lambda_l - max_coef, not max_coef:
+        # for an odd length those differ and the assignment did not fit.
+        mirror = slice(1, lambda_l - max_coef)
         coefsr[max_coef + 1:] = np.real(
-                coefsr[1:max_coef])[::-1] - 1j * np.imag(
-                        coefsr[1:max_coef])[::-1]
+                coefsr[mirror])[::-1] - 1j * np.imag(
+                        coefsr[mirror])[::-1]
         sr = np.fft.ifft(coefsr).real
         s = np.vstack((sl, sr))
     # If in need to force energy to be preserved, try:

--- a/music/core/functions.py
+++ b/music/core/functions.py
@@ -2,6 +2,18 @@
 import numpy as np
 
 
+def _scaled(values, factor):
+    """Divide by `factor`, or return silence when there is nothing to scale.
+
+    A constant signal has no dynamic range: once its offset is removed it
+    is silence, and the scale factor is zero. Dividing anyway filled the
+    result with NaN.
+    """
+    if factor == 0:
+        return np.zeros_like(values, dtype=np.float64)
+    return values / factor
+
+
 def normalize_mono(sonic_vector, remove_bias=True):
     """
     Normalize a mono sonic vector.
@@ -32,17 +44,14 @@ def normalize_mono(sonic_vector, remove_bias=True):
     array([-1.,  0.,  1.])
 
     """
-    t = np.array(sonic_vector)
-    if np.all(t == 0):
-        return t
-    else:
-        if remove_bias:
-            s = t - t.mean()
-            fact = max(s.max(), -s.min())
-            s = s / fact
-        else:
-            s = ((t - t.min()) / (t.max() - t.min())) * 2. - 1.
-        return s
+    t = np.array(sonic_vector, dtype=np.float64)
+    if t.max() == t.min():
+        # Constant, including all-zero: silence once the offset is gone.
+        return np.zeros_like(t)
+    if remove_bias:
+        s = t - t.mean()
+        return _scaled(s, max(s.max(), -s.min()))
+    return ((t - t.min()) / (t.max() - t.min())) * 2. - 1.
 
 
 def normalize_stereo(sonic_vector, remove_bias=True, normalize_sep=False):
@@ -68,31 +77,37 @@ def normalize_stereo(sonic_vector, remove_bias=True, normalize_sep=False):
         A numpy array with values between -1 and 1.
 
     """
-    sv_copy = np.array(sonic_vector)
-    if np.all(sv_copy == 0):
-        return sv_copy
+    sv_copy = np.array(sonic_vector, dtype=np.float64)
+    if sv_copy.max() == sv_copy.min():
+        # Constant, including all-zero: silence once the offset is gone.
+        return np.zeros_like(sv_copy)
 
     if remove_bias:
         sv_normalized = sv_copy
         sv_normalized[0] = sv_normalized[0] - sv_normalized[0].mean()
         sv_normalized[1] = sv_normalized[1] - sv_normalized[1].mean()
         if normalize_sep:
-            fact = max(sv_normalized[0].max(), -sv_normalized[0].min())
-            sv_normalized[0] = sv_normalized[0] / fact
-            fact = max(sv_normalized[1].max(), -sv_normalized[1].min())
-            sv_normalized[1] = sv_normalized[1] / fact
+            for channel in (0, 1):
+                values = sv_normalized[channel]
+                sv_normalized[channel] = _scaled(
+                    values, max(values.max(), -values.min())
+                )
         else:
-            fact = max(sv_normalized.max(), -sv_normalized.min())
-            sv_normalized = sv_normalized / fact
+            sv_normalized = _scaled(
+                sv_normalized,
+                max(sv_normalized.max(), -sv_normalized.min())
+            )
     else:
         amplitude_ch_1 = sv_copy[0].max() - sv_copy[0].min()
         amplitude_ch_2 = sv_copy[1].max() - sv_copy[1].min()
         if normalize_sep:
-            sv_copy[0] = (sv_copy[0] - sv_copy[0].min()) / amplitude_ch_1
-            sv_copy[1] = (sv_copy[1] - sv_copy[1].min()) / amplitude_ch_2
+            sv_copy[0] = _scaled(sv_copy[0] - sv_copy[0].min(),
+                                 amplitude_ch_1)
+            sv_copy[1] = _scaled(sv_copy[1] - sv_copy[1].min(),
+                                 amplitude_ch_2)
             sv_normalized = sv_copy * 2 - 1
         else:
             amplitude = max(amplitude_ch_1, amplitude_ch_2)
-            sv_copy = (sv_copy - sv_copy.min()) / amplitude
+            sv_copy = _scaled(sv_copy - sv_copy.min(), amplitude)
             sv_normalized = sv_copy * 2 - 1
     return sv_normalized

--- a/music/core/synths/notes.py
+++ b/music/core/synths/notes.py
@@ -503,6 +503,26 @@ def note_with_glissando_vibrato(start_freq=220, end_freq=440, duration=2,
 
 
 # FIXME: Unused param (`number_of_samples`)
+def _exponential_positions(start, end, curve):
+    """Interpolate exponentially from `start` to `end` along `curve`.
+
+    Raises
+    ------
+    ValueError
+        If the two ends have opposite signs, or either is zero. The
+        expression is ``start * (end / start) ** curve``, and a negative
+        base raised to a fractional power is not a real number -- it
+        silently produced NaN, which then propagated into the audio.
+    """
+    if start == 0 or end == 0 or (start < 0) != (end < 0):
+        raise ValueError(
+            f"an exponential transition cannot run from {start} to {end}: "
+            "the positions must share a sign and be non-zero. Use 'lin' "
+            "for a path that crosses the listener."
+        )
+    return start * (end / start) ** curve
+
+
 def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
                                        durations=((2, 3), (2, 5, 3),
                                                   (2, 5, 6, 1, .4),
@@ -656,8 +676,8 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
                     foo = np.arange(lambda_d + 1) / lambda_d
                 else:
                     foo = (np.arange(lambda_d + 1) / lambda_d) ** a
-                xi = x[i] * (x[i + 1] / x[i]) ** foo
-                yi = y[i] * (y[i + 1] / y[i]) ** foo
+                xi = _exponential_positions(x[i], x[i + 1], foo)
+                yi = _exponential_positions(y[i], y[i + 1], foo)
             else:
                 xi = x[i] + (x[i + 1] - x[i]) * np.arange(lambda_d + 1) / \
                     lambda_d
@@ -688,8 +708,8 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
                     foo = np.arange(lambda_d + 1) / lambda_d
                 else:
                     foo = (np.arange(lambda_d + 1) / lambda_d) ** a
-                xi = x[i] * (x[i + 1] / x[i]) ** foo
-                yi = y[i] * (y[i + 1] / y[i]) ** foo
+                xi = _exponential_positions(x[i], x[i + 1], foo)
+                yi = _exponential_positions(y[i], y[i + 1], foo)
             else:
                 xi = x[i] + (x[i + 1] - x[i]) * np.arange(lambda_d + 1) / \
                     lambda_d

--- a/music/legacy/CanonicalSynth.py
+++ b/music/legacy/CanonicalSynth.py
@@ -126,18 +126,16 @@ class CanonicalSynth:
         """
         if not table:
             table = self.tables.triangle
-        if vibrato_depth and vibrato_frequency:
-            vibrato = True
-            if not vibrato_table:
-                vibrato_table = self.tables.sine
-        else:
-            vibrato = False
-        if tremolo_depth and tremolo_frequency:
-            tremolo = True
-            if not tremolo_table:
-                tremolo_table = self.tables.sine
-        else:
-            tremolo = False
+        # The tables are filled in either way. rawRender and tremoloEnvelope
+        # read them unconditionally, so leaving them None when the effect is
+        # off made switching it off a TypeError -- and a depth of zero
+        # already makes the modulation a no-op: 2 ** 0 and 10 ** 0 are 1.
+        if not vibrato_table:
+            vibrato_table = self.tables.sine
+        if not tremolo_table:
+            tremolo_table = self.tables.sine
+        vibrato = bool(vibrato_depth and vibrato_frequency)
+        tremolo = bool(tremolo_depth and tremolo_frequency)
         locals_ = locals().copy()
         del locals_["self"]
         vars(self).update(locals_)
@@ -251,7 +249,9 @@ class CanonicalSynth:
             Tremolo envelope.
         """
         self.absorbState(**statevars)
-        if sonic_vector:
+        # `is not None`, as the return below already does: truth-testing an
+        # array raises, so passing one here was a ValueError.
+        if sonic_vector is not None:
             Lambda = len(sonic_vector)
         else:
             Lambda = n.floor(self.samplerate * self.duration)

--- a/music/legacy/classes.py
+++ b/music/legacy/classes.py
@@ -169,7 +169,15 @@ class Being:
                                   self.seqsize] for i in range(n*self.seqsize)]
         elif method == 'perm-walk':
             # restore walk from 02peal
-            pass
+            raise NotImplementedError(
+                "the 'perm-walk' method was never restored from 02peal; "
+                "use 'straight' or 'low-high', or stay(method='perm')"
+            )
+        else:
+            raise ValueError(
+                f"method not understood: {method!r}; expected 'straight', "
+                "'low-high' or 'perm-walk'"
+            )
         self.addSeq(sequence)
 
     def setPar(self, par='f'):
@@ -178,16 +186,28 @@ class Being:
         Parameters
         ----------
         par : str
-            Parameter to be set.
+            Parameter to be set. Only 'f' is implemented, and it requires
+            `fgrid` and `fpointer` to have been assigned by the caller, as
+            `perms`, `domain` and `curseq` are.
 
         Returns
         -------
         None
 
+        Raises
+        ------
+        ValueError
+            If `par` is anything but 'f'. It used to be a silent no-op.
+
         """
-        if par == 'f':
-            self.grid = self.fgrid
-            self.pointer = self.fpointer
+        if par != 'f':
+            raise ValueError(
+                f"only the 'f' parameter has a grid to switch to; got "
+                f"{par!r}. Set curseq directly to choose which sequence "
+                "walk() and stay() fill."
+            )
+        self.grid = self.fgrid
+        self.pointer = self.fpointer
 
     def setSize(self, ss):
         """Set the size.

--- a/music/singing/perform.py
+++ b/music/singing/perform.py
@@ -114,6 +114,6 @@ class Notes:
 
 converter = Notes()
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover - a manual smoke run
     narray = sing()
     logging.info("finished")

--- a/music/structures/peals/plain_changes.py
+++ b/music/structures/peals/plain_changes.py
@@ -37,9 +37,10 @@ class PlainChanges:
         """
         self.peal_direct = None
         self.peal_sequence = None
+        # Filled by perform_peal below, which __init__ always calls.
+        self.peals: dict = {}
         self.domain = None
         self.acted_peals = None
-        self.peals = None
         hunts = self.initialize_hunts(nelements, nhunts)
         self.neutral_perm = sympy.combinatorics.Permutation([0],
                                                             size=nelements)
@@ -151,6 +152,10 @@ class PlainChanges:
             peal_sequence += [permutation]
         self.peal_direct = peal_direct
         self.peal_sequence = peal_sequence
+        # act_all() iterates this mapping; it was left as None, so the
+        # method could never run on a PlainChanges.
+        self.peals = {"peal_direct": peal_direct,
+                      "peal_sequence": peal_sequence}
         return hunts
 
     def perform_change(self, nelements, hunts, hunt=None):
@@ -243,7 +248,6 @@ class PlainChanges:
         """
         if domain is None:
             domain = list(range(self.nelements))
-        assert self.peals is not None
         acted_peals = {}
         for peal in self.peals:
             acted_peals[peal + "_acted"] = [i(domain)

--- a/music/utils.py
+++ b/music/utils.py
@@ -410,12 +410,17 @@ def mix_stereo(
     If `second_sonic_vector` is not provided, the `end` parameter is ignored.
 
     """
-    if len(first_sonic_vector) != 2:
+    # ndim, not len: a two-sample mono vector also has len() == 2, and was
+    # taken for a stereo pair whose channels were then indexed as scalars.
+    first_sonic_vector = np.asarray(first_sonic_vector, dtype=np.float64)
+    if first_sonic_vector.ndim != 2:
         first_sonic_vector = np.array((first_sonic_vector, first_sonic_vector))
     if second_sonic_vector is None:
         second_sonic_vector = first_sonic_vector
     else:
-        if len(second_sonic_vector) != 2:
+        second_sonic_vector = np.asarray(second_sonic_vector,
+                                         dtype=np.float64)
+        if second_sonic_vector.ndim != 2:
             second_sonic_vector = np.array((second_sonic_vector,
                                             second_sonic_vector))
 
@@ -568,7 +573,10 @@ def mix_with_offset(
     first_sonic_vector = np.array(first_sonic_vector)
     second_sonic_vector = np.array(second_sonic_vector)
     if 2 in [len(first_sonic_vector.shape), len(second_sonic_vector.shape)]:
-        return resolve_stereo(mix_with_offset, locals(), ['s1', 's2'])
+        # The parameters were renamed from s1/s2 at some point but these
+        # names were not, so the stereo path raised KeyError.
+        return resolve_stereo(mix_with_offset, locals(),
+                              ['first_sonic_vector', 'second_sonic_vector'])
     dur = duration
 
     if not number_of_samples:  # sample in s1 where s2[0] is added
@@ -643,10 +651,12 @@ def mix_with_offset_(*args: ArrayLike) -> NDArray[np.float64]:
     s: NDArray[np.float64] = np.array([])
     while i < len(args):
         a = args[i]  # new array
-        if type(a) not in (np.ndarray, list):
+        # np.ndim rather than an exact type check, which rejected tuples and
+        # ndarray subclasses although the parameters are array_like.
+        if np.ndim(a) == 0:
             raise ValueError(
-                "Skipping a value that should have been a sequence of numbers:"
-                f" {a!r}")
+                "expected a sequence of numbers at position "
+                f"{i}, got {a!r}")
         if len(args) > i + 1:
             off: Any = args[i + 1]
             if np.isscalar(off):
@@ -751,11 +761,10 @@ def pan_transitions(p=((1, 1), (1, 0), (0, 1), (1, 1)), d=(2, 2, 2),
     t0__ = horizontal_stack(*t0_)
     t1__ = horizontal_stack(*t1_)
     t = np.array((t0__, t1__))
-    if sonic_vector:
+    if sonic_vector is not None:
         sonic_vector = convert_to_stereo(sonic_vector)
         return mix_with_offset(sonic_vector, t)
-    else:
-        return t
+    return t
 
 
 def mix2(sonic_vectors, end=False, offset=0, sample_rate=44100):

--- a/tests/test_abc_notation.py
+++ b/tests/test_abc_notation.py
@@ -1,0 +1,147 @@
+"""Turning notes and durations into ABC notation.
+
+The singing engine is a Perl program that cannot run in CI, but everything
+this package does *before* handing over to it is pure string generation.
+"""
+
+import numpy as np
+import pytest
+
+import music.singing.paths as paths
+import music.singing.perform as perform
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch):
+    """Point the engine at a writable scratch directory."""
+    engine = tmp_path / "engine"
+    (engine / "cache").mkdir(parents=True)
+    monkeypatch.setenv(paths.ENV_VAR, str(engine))
+    return engine / "cache"
+
+
+# --------------------------------------------------------------------------
+# Pitch names
+# --------------------------------------------------------------------------
+
+def test_semitones_become_abc_pitch_names():
+    """Relative to a reference of 60, zero is middle c."""
+    assert perform.converter.convert((0, 4, 7, 12), 60) == \
+        ["=c", "e", "=g", "=c'"]
+
+
+def test_octaves_change_case_and_add_marks():
+    """ABC writes the octave below in upper case and the one above with a
+    prime."""
+    assert perform.converter.convert((-12, 0, 12), 60) == ["=C", "=c", "=c'"]
+
+
+def test_the_dictionary_is_rebuilt_if_it_goes_missing():
+    notes = perform.Notes()
+    notes.notes_dict = None
+    assert notes.convert((0,), 60) == ["=c"]
+
+
+# --------------------------------------------------------------------------
+# Durations
+# --------------------------------------------------------------------------
+
+def test_a_duration_of_one_is_left_implicit():
+    """ABC takes the unit length as the default, so 1 is written as
+    nothing."""
+    assert perform.translate_to_abc((0,), (1,), 60) == "=c"
+
+
+def test_other_durations_follow_their_note():
+    assert perform.translate_to_abc((0, 4), (1, 2), 60) == "=ce2"
+
+
+def test_a_negative_duration_becomes_a_division():
+    """`-2` is written `/2`, ABC's notation for a half-length note."""
+    assert perform.translate_to_abc((0,), (-2,), 60) == "=c/2"
+
+
+# --------------------------------------------------------------------------
+# The .abc file
+# --------------------------------------------------------------------------
+
+def test_write_abc_emits_a_well_formed_header(cache):
+    perform.write_abc("la la", (0, 4), (1, 1), M="3/4", L="1/8", Q=90, K="G")
+
+    written = (cache / "achant.abc").read_text()
+    assert written.startswith("X:1\n")
+    for field in ("M:3/4", "L:1/8", "Q:90", "V:1", "K:G"):
+        assert field in written
+
+
+def test_write_abc_carries_the_lyric_line(cache):
+    perform.write_abc("hey ma bro", (0, 4, 7), (1, 1, 1))
+    written = (cache / "achant.abc").read_text()
+    assert written.rstrip().endswith("w: hey ma bro")
+    assert "=ce=g" in written
+
+
+# --------------------------------------------------------------------------
+# sing()'s own branches
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("effect, expected", [
+    ("flint", "flite.inc"),
+    ("tremolo", "tremolo.inc"),
+    ("melt", "melt.inc"),
+])
+def test_each_effect_selects_its_include(cache, effect, expected,
+                                         monkeypatch):
+    """The effect names an extra voice for the engine to `do`."""
+    engine = cache.parent
+    (engine / "Makefile").write_text("all:\n\ttrue\n")
+    monkeypatch.setattr(paths, "missing_requirements", lambda: [])
+    monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(perform.wavfile, "read",
+                        lambda path: (44100, np.zeros(4)))
+
+    perform.sing(effect=effect)
+
+    assert expected in (cache / "achant.conf").read_text()
+
+
+def test_the_language_and_transposition_reach_the_conf(cache, monkeypatch):
+    engine = cache.parent
+    (engine / "Makefile").write_text("all:\n\ttrue\n")
+    monkeypatch.setattr(paths, "missing_requirements", lambda: [])
+    monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(perform.wavfile, "read",
+                        lambda path: (44100, np.zeros(4)))
+
+    perform.sing(lang="pt", transpose=-24)
+
+    conf = (cache / "achant.conf").read_text()
+    assert '$ESPEAK_VOICE = "pt";' in conf
+    assert "$ESPEAK_TRANSPOSE = -24;" in conf
+
+
+def test_sing_returns_normalized_samples(cache, monkeypatch):
+    engine = cache.parent
+    (engine / "Makefile").write_text("all:\n\ttrue\n")
+    monkeypatch.setattr(paths, "missing_requirements", lambda: [])
+    monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(perform.wavfile, "read",
+                        lambda path: (44100, np.array([0.0, 1.0, 2.0])))
+
+    out = perform.sing()
+
+    assert np.allclose(out, [-1.0, 0.0, 1.0])
+
+
+def test_sing_rejects_a_render_at_the_wrong_sample_rate(cache, monkeypatch):
+    """The engine is expected to produce 44100 Hz; anything else would be
+    silently the wrong pitch."""
+    engine = cache.parent
+    (engine / "Makefile").write_text("all:\n\ttrue\n")
+    monkeypatch.setattr(paths, "missing_requirements", lambda: [])
+    monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(perform.wavfile, "read",
+                        lambda path: (22050, np.zeros(4)))
+
+    with pytest.raises(RuntimeError, match="44100"):
+        perform.sing()

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -1,0 +1,311 @@
+"""The alternative branches of parametrised routines.
+
+Most of this package's functions take a `method`, an `alpha`, a `stereo`
+flag or a choice of duration parameter, and the suite reached only the
+default of each. Two of the defects found earlier -- `fir` and the mono
+path of `note_with_vibrato_seq_localization` -- were hiding exactly here.
+"""
+
+import itertools
+
+import numpy as np
+import pytest
+from sympy.combinatorics import Permutation
+
+import music
+from music.core.filters.fade import cross_fade
+from music.utils import mix_with_offset, rhythm_to_durations
+
+
+def _finite(array):
+    array = np.asarray(array)
+    return array.size > 0 and np.isfinite(array).all()
+
+
+# --------------------------------------------------------------------------
+# Pitch transitions: alpha != 1 takes a different curve
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("alpha", [1, 2.0, 0.5])
+@pytest.mark.parametrize("method", ["exp", "lin"])
+def test_glissando_curves(alpha, method):
+    out = music.note_with_glissando(start_freq=220, end_freq=440,
+                                    duration=0.05, alpha=alpha, method=method)
+    assert _finite(out)
+
+
+@pytest.mark.parametrize("alpha", [1, 2.0])
+def test_glissando_with_vibrato_curves(alpha):
+    out = music.note_with_glissando_vibrato(
+        start_freq=220, end_freq=440, duration=0.05, alpha=alpha
+    )
+    assert _finite(out)
+
+
+@pytest.mark.parametrize("alpha", [1, 2.0])
+def test_note_with_vibrato_curves(alpha):
+    assert _finite(music.note_with_vibrato(duration=0.05, alpha=alpha))
+
+
+@pytest.mark.parametrize("alphav1", [1, 2.0])
+def test_two_vibratos_curves(alphav1):
+    assert _finite(music.note_with_two_vibratos(duration=0.05,
+                                                alphav1=alphav1))
+
+
+@pytest.mark.parametrize("alpha", [1, 2.0])
+def test_two_vibratos_glissando_curves(alpha):
+    assert _finite(music.note_with_two_vibratos_glissando(
+        duration=0.05, alpha=alpha))
+
+
+def test_vibratos_glissandos_renders():
+    assert _finite(music.note_with_vibratos_glissandos())
+
+
+# --------------------------------------------------------------------------
+# Localization: the sign of x picks which ear leads
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("x", [0.5, -0.5])
+def test_localize_from_either_side(x):
+    out = music.localize(sonic_vector=music.note(duration=0.05), x=x, y=0.1)
+    assert out.shape[0] == 2 and _finite(out)
+
+
+def test_localize_by_angle_and_distance():
+    """theta and distance are an alternative to x and y."""
+    out = music.localize(sonic_vector=music.note(duration=0.05),
+                         theta=45, distance=1.0)
+    assert out.shape[0] == 2 and _finite(out)
+
+
+@pytest.mark.parametrize("theta", [0, -70, 70])
+def test_localize2_across_angles(theta):
+    with _nullcontext():
+        out = music.localize2(sonic_vector=np.ones(2048), theta=theta)
+    assert out.shape[0] == 2 and _finite(out)
+
+
+@pytest.mark.parametrize("length", [2048, 2049, 1101, 999])
+def test_localize2_handles_an_odd_number_of_samples(length):
+    """Regression: the conjugate mirror ran to max_coef, which only
+    balances for an even length. Every odd-length input raised."""
+    with _nullcontext():
+        out = music.localize2(sonic_vector=np.ones(length))
+    assert out.shape == (2, length)
+    assert _finite(out)
+
+
+@pytest.mark.parametrize("x", [0.1, -0.1])
+def test_note_with_doppler_from_either_side(x):
+    out = music.note_with_doppler(x=(x, -x), number_of_samples=2000)
+    assert _finite(out)
+
+
+class _nullcontext:
+    def __enter__(self):
+        import warnings
+        self._cm = warnings.catch_warnings()
+        self._cm.__enter__()
+        warnings.simplefilter("ignore")
+        return self
+
+    def __exit__(self, *exc):
+        return self._cm.__exit__(*exc)
+
+
+# --------------------------------------------------------------------------
+# Envelopes and fades
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("to", [True, False])
+@pytest.mark.parametrize("alpha", [1, 2.0])
+def test_loud_directions_and_curves(to, alpha):
+    assert _finite(music.loud(duration=0.05, to=to, alpha=alpha))
+
+
+def test_louds_can_be_driven_by_sample_counts():
+    """number_of_samples is the alternative to durations."""
+    out = music.louds(number_of_samples=(500, 500), trans_devs=(6, -6),
+                      alpha=(1, 1), method=("exp", "exp"))
+    assert _finite(out)
+
+
+@pytest.mark.parametrize("fade_out", [True, False])
+@pytest.mark.parametrize("method", ["exp", "lin"])
+def test_fade_directions_and_methods(fade_out, method):
+    assert _finite(music.fade(duration=0.05, fade_out=fade_out,
+                              method=method))
+
+
+def test_fade_resolves_a_stereo_vector_per_channel():
+    stereo = np.vstack((music.note(duration=0.05),) * 2)
+    out = music.fade(sonic_vector=stereo)
+    assert out.shape[0] == 2 and _finite(out)
+
+
+def test_cross_fade_handles_stereo_pairs():
+    stereo = np.vstack((music.note(duration=0.1),) * 2)
+    out = cross_fade(stereo, stereo * 0.5, duration=10)
+    assert out.shape[0] == 2 and _finite(out)
+
+
+def test_cross_fade_rejects_mismatched_shapes():
+    mono = music.note(duration=0.05)
+    stereo = np.vstack((mono, mono))
+    with pytest.raises(ValueError, match="same shape"):
+        cross_fade(mono, stereo)
+
+
+def test_tremolos_pads_a_shorter_sonic_vector():
+    out = music.tremolos(sonic_vector=music.note(duration=0.05))
+    assert _finite(out)
+
+
+# --------------------------------------------------------------------------
+# Rhythm
+# --------------------------------------------------------------------------
+
+def test_rhythm_from_beats_per_minute():
+    assert _finite(rhythm_to_durations(durations=[4, 2, 2], bpm=120))
+
+
+def test_rhythm_from_a_total_duration():
+    out = rhythm_to_durations(durations=[4, 2, 2], total_duration=4)
+    assert sum(out) == pytest.approx(4)
+
+
+def test_rhythm_from_frequencies_and_a_total_duration():
+    out = rhythm_to_durations(freqs=[4, 8, 8], total_duration=2)
+    assert sum(out) == pytest.approx(2)
+
+
+def test_rhythm_with_nested_tuplets():
+    """A nested iterable is a tuplet: its first value is the cell's own
+    duration and the rest divide it."""
+    out = rhythm_to_durations(durations=[4, [2, 1, 1], 2], duration=0.5)
+    assert _finite(out)
+
+
+def test_rhythm_frequencies_with_nested_tuplets():
+    out = rhythm_to_durations(freqs=[4, [2, 3, 3], 4], duration=4)
+    assert _finite(out)
+
+
+# --------------------------------------------------------------------------
+# Mixing offsets
+# --------------------------------------------------------------------------
+
+def test_mix_with_offset_places_the_second_vector_later():
+    out = mix_with_offset(np.ones(100), np.ones(50) * 2, duration=0.001)
+    assert _finite(out)
+
+
+def test_mix_with_offset_accepts_a_number_of_samples():
+    out = mix_with_offset(np.ones(100), np.ones(50) * 2,
+                          number_of_samples=20)
+    assert len(out) == 100
+
+
+@pytest.mark.parametrize("stereo", [True, False])
+def test_pan_transitions_accepts_a_sonic_vector(stereo):
+    """Regression: `if sonic_vector:` truth-tested the array, so passing
+    one raised 'truth value of an array is ambiguous'."""
+    tone = music.note(duration=0.3)
+    signal = np.vstack((tone, tone)) if stereo else tone
+
+    out = music.pan_transitions(d=(0.1, 0.1, 0.1), sonic_vector=signal)
+
+    assert out.shape[0] == 2 and _finite(out)
+
+
+@pytest.mark.parametrize("first_stereo", [True, False])
+@pytest.mark.parametrize("second_stereo", [True, False])
+def test_mix_with_offset_across_channel_combinations(first_stereo,
+                                                     second_stereo):
+    """Regression: the stereo path passed ['s1', 's2'] to resolve_stereo,
+    parameter names that had been renamed, and raised KeyError."""
+    tone = music.note(duration=0.05)
+    first = np.vstack((tone, tone)) if first_stereo else tone
+    second = np.vstack((tone, tone)) if second_stereo else tone
+
+    out = music.mix_with_offset(first, second)
+
+    expected_dims = 2 if (first_stereo or second_stereo) else 1
+    assert out.ndim == expected_dims
+    assert _finite(out)
+
+
+# --------------------------------------------------------------------------
+# Permutations and peals
+# --------------------------------------------------------------------------
+
+def test_even_odd_agrees_with_sympy_for_every_permutation():
+    """The parity of a permutation is the parity of its transposition
+    count; checked exhaustively rather than by example."""
+    perms = music.InterestingPermutations(nelements=4)
+    for sequence in itertools.permutations(range(4)):
+        expected = "odd" if Permutation(list(sequence)).parity() else "even"
+        assert perms.even_odd(list(sequence)) == expected
+
+
+def test_interesting_permutations_of_a_pair():
+    """Two elements is the degenerate dihedral case."""
+    perms = music.InterestingPermutations(nelements=2)
+    assert perms.dihedral
+
+
+def test_plain_changes_acts_on_its_own_domain_by_default():
+    peal = music.PlainChanges(3)
+    rows = peal.act()
+    assert len(rows) == len(peal.peal_direct)
+    for row in rows:
+        assert sorted(row) == [0, 1, 2]
+
+
+def test_plain_changes_acts_on_a_given_domain():
+    rows = music.PlainChanges(3).act(domain=[220, 440, 330])
+    assert all(sorted(row) == [220, 330, 440] for row in rows)
+
+
+def test_plain_changes_act_all_records_every_peal():
+    """Regression: `peals` was left as None, so act_all could never run on
+    a PlainChanges even though the class builds two of them."""
+    peal = music.PlainChanges(3)
+    assert set(peal.peals) == {"peal_direct", "peal_sequence"}
+
+    peal.act_all()
+
+    assert set(peal.acted_peals) == {"peal_direct_acted",
+                                     "peal_sequence_acted"}
+    assert peal.domain == [0, 1, 2]
+
+
+# --------------------------------------------------------------------------
+# Error branches
+# --------------------------------------------------------------------------
+
+def test_noise_rejects_an_unknown_colour():
+    with pytest.raises(ValueError, match="Set ntype"):
+        music.noise("chartreuse")
+
+
+def test_stretches_rejects_a_non_positive_duration():
+    with pytest.raises(ValueError, match="must be positive"):
+        music.stretches(music.note(duration=0.05), durations=(1, 0))
+
+
+def test_writing_nan_is_refused(tmp_path):
+    with pytest.raises(ValueError, match="NaN or infinity"):
+        music.write_wav_mono(np.array([0.0, np.nan, 1.0]),
+                             filename=str(tmp_path / "x.wav"))
+
+
+def test_generic_peal_needs_nelements_for_a_default_domain():
+    holder = music.GenericPeal()
+    holder.peals = {"p": [Permutation([1, 0, 2])]}
+    with pytest.raises(ValueError, match="nelements has not been set"):
+        holder.act("p")
+    with pytest.raises(ValueError, match="nelements has not been set"):
+        holder.act_all()

--- a/tests/test_io_paths.py
+++ b/tests/test_io_paths.py
@@ -1,0 +1,140 @@
+"""The reading and writing paths that the round-trip tests do not reach."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from scipy.io import wavfile
+
+import music
+from music.core.io import _fade_pair
+
+
+# --------------------------------------------------------------------------
+# fades
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("fades, expected", [
+    (20, (20, 20)),
+    (20.0, (20, 20)),
+    (np.int64(20), (20, 20)),
+    ((10, 30), (10, 30)),
+    ([10, 30], (10, 30)),
+    (np.array([10, 30]), (10, 30)),
+])
+def test_fade_pair_resolves_every_documented_form(fades, expected):
+    """A scalar applies to both ends; a pair is taken as given."""
+    assert _fade_pair(fades) == expected
+
+
+@pytest.mark.parametrize("stereo", [False, True])
+def test_a_scalar_fade_is_applied_at_both_ends(stereo, tmp_path):
+    """Regression: a scalar `fades` used to be silently ignored."""
+    path = tmp_path / "faded.wav"
+    tone = music.note(440, 0.2)
+    signal = np.vstack((tone, tone)) if stereo else tone
+    writer = music.write_wav_stereo if stereo else music.write_wav_mono
+
+    writer(signal, filename=str(path), fades=20)
+    faded = music.read_wav(str(path))
+    writer(signal, filename=str(path), fades=0)
+    plain = music.read_wav(str(path))
+
+    channel = (lambda a: a[0]) if stereo else (lambda a: a)
+    # The opening of the faded render is quieter than the unfaded one.
+    opening = slice(0, 200)
+    assert (np.abs(channel(faded)[opening]).max()
+            < np.abs(channel(plain)[opening]).max())
+
+
+# --------------------------------------------------------------------------
+# defaults
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("writer, channels", [
+    (music.write_wav_mono, 1),
+    (music.write_wav_stereo, 2),
+])
+def test_the_writers_render_noise_when_given_nothing(writer, channels,
+                                                     tmp_path):
+    """The default is a couple of seconds of uniform noise, generated on
+    the call rather than at import."""
+    path = tmp_path / "default.wav"
+    writer(filename=str(path))
+
+    restored = music.read_wav(str(path))
+    assert (restored.ndim == 1 if channels == 1 else restored.shape[0] == 2)
+    assert restored.size > 0
+
+
+# --------------------------------------------------------------------------
+# reading
+# --------------------------------------------------------------------------
+
+def test_a_float_wav_is_scaled_by_its_own_peak(tmp_path):
+    path = tmp_path / "float.wav"
+    wavfile.write(path, 8000, np.array([0.0, 0.25, -0.5], dtype=np.float32))
+
+    out = music.read_wav(str(path))
+
+    assert out.max() == pytest.approx(0.5)
+    assert out.min() == pytest.approx(-1.0)
+
+
+def test_an_all_zero_float_wav_does_not_divide_by_zero(tmp_path):
+    path = tmp_path / "silent.wav"
+    wavfile.write(path, 8000, np.zeros(8, dtype=np.float32))
+
+    assert np.array_equal(music.read_wav(str(path)), np.zeros(8))
+
+
+def test_an_unsupported_sample_format_is_reported(tmp_path):
+    path = tmp_path / "odd.wav"
+    with patch.object(wavfile, "read",
+                      return_value=(8000, np.zeros(4, dtype=np.complex64))):
+        with pytest.raises(ValueError, match="unsupported WAV data type"):
+            music.read_wav(str(path))
+
+
+def test_an_unsupported_integer_depth_is_reported(tmp_path):
+    path = tmp_path / "odd.wav"
+    with patch.object(wavfile, "read",
+                      return_value=(8000, np.zeros(4, dtype=np.int64))):
+        with pytest.raises(ValueError, match="unsupported integer WAV bit"):
+            music.read_wav(str(path))
+
+
+# --------------------------------------------------------------------------
+# playback
+# --------------------------------------------------------------------------
+
+def test_play_audio_transposes_stereo_for_the_device():
+    """sounddevice wants (samples, channels); the package uses
+    (channels, samples)."""
+    device = types.SimpleNamespace(play=MagicMock(), wait=MagicMock())
+    stereo = np.vstack((np.ones(8), np.zeros(8)))
+
+    with patch.dict(sys.modules, {"sounddevice": device}):
+        music.play_audio(stereo, sample_rate=8000)
+
+    passed = device.play.call_args[0][0]
+    assert passed.shape == (8, 2)
+
+
+def test_play_audio_can_skip_normalization():
+    device = types.SimpleNamespace(play=MagicMock(), wait=MagicMock())
+    quiet = np.full(8, 0.25)
+
+    with patch.dict(sys.modules, {"sounddevice": device}):
+        music.play_audio(quiet, sample_rate=8000, normalize=False)
+
+    assert np.allclose(device.play.call_args[0][0], quiet)
+
+
+def test_play_audio_says_so_when_sounddevice_is_missing(caplog):
+    """It is an optional dependency, so this is a warning, not an error."""
+    with patch.dict(sys.modules, {"sounddevice": None}):
+        music.play_audio(np.zeros(4))
+    assert "sounddevice" in caplog.text

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -164,3 +164,155 @@ def test_the_module_level_synth_is_an_instance():
     from music.legacy.pieces import testSong2
 
     assert isinstance(testSong2.synth, CanonicalSynth)
+
+
+# --------------------------------------------------------------------------
+# Being: walking, staying and rendering
+# --------------------------------------------------------------------------
+
+def _being_with_grid(size=8):
+    """A Being with a grid and pointer ready to walk."""
+    being = music.Being()
+    being.grid = list(range(size))
+    being.pointer = 0
+    being.seqsize = size
+    being.curseq = "f_"
+    being.f_ = []
+    return being
+
+
+def test_walk_takes_consecutive_steps_from_the_grid():
+    being = _being_with_grid()
+    being.walk(3)
+    assert list(being.f_) == [0, 1, 2]
+    assert being.pointer == 3
+
+
+def test_walk_low_high_interleaves_across_the_sequence():
+    being = _being_with_grid(size=8)
+    being.seqsize = 4
+    being.walk(2, method="low-high")
+    assert len(being.f_) == 2 * being.seqsize
+
+
+def test_walk_rejects_an_unknown_method():
+    """Regression: `sequence` was only assigned inside the recognised
+    branches, so anything else died on UnboundLocalError."""
+    being = _being_with_grid()
+    with pytest.raises(ValueError, match="method not understood"):
+        being.walk(2, method="sideways")
+
+
+def test_walk_says_perm_walk_was_never_restored():
+    being = _being_with_grid()
+    with pytest.raises(NotImplementedError, match="perm-walk"):
+        being.walk(2, method="perm-walk")
+
+
+def test_stay_permutes_the_domain():
+    """The campanology example's second form: a domain plus permutations,
+    with `curseq` naming which parameter sequence to fill."""
+    being = music.Being()
+    being.domain = [220, 440, 330]
+    being.perms = music.PlainChanges(3).peal_direct
+    being.curseq = "f_"
+    being.f_ = []
+
+    being.stay(6)
+
+    assert len(being.f_) == 6
+    assert set(being.f_) <= {220, 440, 330}
+    assert being.total_notes == 6
+
+
+def test_stay_falls_back_to_the_grid_when_no_domain_is_set():
+    """Without a domain it permutes a slice of the grid, so the slice has
+    to be as wide as the permutations."""
+    being = _being_with_grid(size=8)
+    being.seqsize = 3
+    being.domain = []
+    being.perms = music.PlainChanges(3).peal_direct
+    being.stay(4)
+    assert len(being.f_) == 4
+
+
+def test_stay_accepts_a_numpy_domain():
+    being = music.Being()
+    being.domain = np.array([220.0, 440.0, 330.0])
+    being.perms = music.PlainChanges(3).peal_direct
+    being.curseq = "f_"
+    being.f_ = []
+    being.stay(3)
+    assert len(being.f_) == 3
+
+
+def test_stay_can_walk_straight_instead():
+    being = _being_with_grid()
+    being.stay(3, method="straight")
+    assert list(being.f_) == [0, 1, 2]
+
+
+def test_render_writes_a_wav_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    being = music.Being()
+    being.f_ = [220.0, 440.0, 330.0]
+
+    being.render(3, "being.wav")
+
+    assert (tmp_path / "being.wav").is_file()
+
+
+def test_render_returns_the_samples_when_given_no_filename():
+    being = music.Being()
+    being.f_ = [220.0, 440.0]
+    out = being.render(2)
+    assert isinstance(out, np.ndarray)
+    assert out.size > 0
+    assert np.isfinite(out).all()
+
+
+def test_set_par_switches_to_the_frequency_grid():
+    """`setPar('f')` reads fgrid/fpointer, which the caller supplies the
+    way it supplies perms and domain."""
+    being = music.Being()
+    being.fgrid, being.fpointer = [1.0, 2.0, 3.0], 1
+
+    being.setPar("f")
+
+    assert being.grid == [1.0, 2.0, 3.0]
+    assert being.pointer == 1
+
+
+def test_set_par_rejects_a_parameter_it_cannot_switch_to():
+    """Regression: anything but 'f' was a silent no-op."""
+    with pytest.raises(ValueError, match="only the 'f' parameter"):
+        music.Being().setPar("d")
+
+
+def test_set_size_and_set_perms_record_what_they_are_given():
+    being = music.Being()
+    being.setSize(11)
+    assert being.seqsize == 11
+
+    perms = music.PlainChanges(3).peal_direct
+    being.setPerms(perms)
+    assert being.perms is perms
+
+
+def test_add_seq_extends_a_list_and_stacks_an_array():
+    being = music.Being()
+    being.curseq = "f_"
+    being.f_ = [1.0]
+    being.addSeq([2.0, 3.0])
+    assert list(being.f_) == [1.0, 2.0, 3.0]
+
+    being.f_ = np.array([1.0])
+    being.addSeq([2.0])
+    assert len(being.f_) == 2
+
+
+def test_howl_and_freeze_are_callable():
+    """Both are placeholders; keep them from silently disappearing."""
+    being = music.Being()
+    being.howl()
+    being.freeze()

--- a/tests/test_mixing.py
+++ b/tests/test_mixing.py
@@ -1,0 +1,117 @@
+"""Combining sonic vectors.
+
+`mix_stereo`, `mix_with_offset_` and `resolve_stereo` had no test exercising
+their bodies at all, and each turned out to have a defect.
+"""
+
+import numpy as np
+import pytest
+
+import music
+from music.utils import mix_stereo, mix_with_offset_, resolve_stereo
+
+
+# --------------------------------------------------------------------------
+# mix_stereo
+# --------------------------------------------------------------------------
+
+def test_mix_stereo_promotes_mono_to_both_channels():
+    mono = np.array([1.0, 2.0, 3.0])
+    out = mix_stereo(mono)
+    assert out.shape == (2, 3)
+    # Mixed with itself, so each channel is doubled.
+    assert np.allclose(out[0], 2 * mono)
+    assert np.allclose(out[1], 2 * mono)
+
+
+@pytest.mark.parametrize("end", [False, True])
+def test_mix_stereo_pads_the_shorter_vector(end):
+    """`end` chooses which side the padding goes on."""
+    longer = np.ones(5)
+    shorter = np.ones(3) * 2
+
+    out = mix_stereo(longer, shorter, end=end)
+
+    assert out.shape == (2, 5)
+    if end:
+        # the short one is pushed to the back
+        assert np.allclose(out[0], [1, 1, 3, 3, 3])
+    else:
+        assert np.allclose(out[0], [3, 3, 3, 1, 1])
+
+
+def test_mix_stereo_handles_either_argument_being_longer():
+    a, b = np.ones(5), np.ones(3) * 2
+    assert mix_stereo(a, b).shape == (2, 5)
+    assert mix_stereo(b, a).shape == (2, 5)
+
+
+def test_mix_stereo_keeps_a_real_stereo_vector_as_is():
+    stereo = np.vstack((np.ones(4), np.ones(4) * 3))
+    out = mix_stereo(stereo, np.zeros(4))
+    assert np.allclose(out[0], 1.0)
+    assert np.allclose(out[1], 3.0)
+
+
+def test_mix_stereo_does_not_mistake_a_two_sample_mono_for_stereo():
+    """Regression: the stereo test was `len(x) != 2`, and a mono vector of
+    two samples also has len 2. Its 'channels' were then scalars, and
+    len() of a scalar raises."""
+    out = mix_stereo(np.array([1.0, 2.0]), np.zeros(3))
+    assert out.shape == (2, 3)
+    assert np.allclose(out[0][:2], [1.0, 2.0])
+
+
+# --------------------------------------------------------------------------
+# mix_with_offset_
+# --------------------------------------------------------------------------
+
+def test_mix_with_offset_sums_vectors_given_without_offsets():
+    out = mix_with_offset_(np.ones(5), np.ones(3) * 2)
+    assert out.shape == (5,)
+    assert np.allclose(out, [3, 3, 3, 1, 1])
+
+
+def test_mix_with_offset_reads_a_scalar_between_vectors_as_a_delay():
+    """The arguments alternate vector, offset-in-seconds, vector..."""
+    out = mix_with_offset_(np.ones(5), 0.5, np.ones(3) * 2)
+    assert out.shape[0] == pytest.approx(0.5 * 44100 + 3, abs=2)
+
+
+def test_mix_with_offset_accepts_any_sequence():
+    """Regression: an exact `type(a) not in (np.ndarray, list)` check
+    rejected tuples, though the parameters are array_like."""
+    from_tuples = mix_with_offset_((1.0,) * 5, (2.0,) * 3)
+    from_lists = mix_with_offset_([1.0] * 5, [2.0] * 3)
+    assert np.allclose(from_tuples, from_lists)
+
+
+def test_mix_with_offset_rejects_a_scalar_where_a_vector_belongs():
+    with pytest.raises(ValueError, match="sequence of numbers"):
+        mix_with_offset_(3.0)
+
+
+def test_mix_with_offset_passes_a_single_vector_through():
+    assert np.allclose(mix_with_offset_(np.ones(4)), np.ones(4))
+
+
+# --------------------------------------------------------------------------
+# resolve_stereo
+# --------------------------------------------------------------------------
+
+def test_resolve_stereo_applies_a_mono_function_per_channel():
+    stereo = np.vstack((np.ones(64), np.ones(64) * 2))
+
+    out = resolve_stereo(music.fade, {"sonic_vector": stereo})
+
+    assert out.shape == (2, 64)
+    # Each channel is the mono result for that channel.
+    assert np.allclose(out[0], music.fade(sonic_vector=stereo[0]))
+    assert np.allclose(out[1], music.fade(sonic_vector=stereo[1]))
+
+
+def test_resolve_stereo_promotes_a_mono_argument_first():
+    mono = np.ones(64)
+    out = resolve_stereo(music.fade, {"sonic_vector": mono})
+    assert out.shape == (2, 64)
+    assert np.allclose(out[0], out[1])

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,117 @@
+"""Normalization of mono and stereo sonic vectors.
+
+`normalize_stereo`'s four combinations of `remove_bias` and `normalize_sep`
+were untested, and they behave quite differently from one another.
+"""
+
+import numpy as np
+import pytest
+
+from music.core.functions import normalize_mono, normalize_stereo
+
+
+def test_mono_all_zero_is_returned_untouched():
+    """There is nothing to scale by, and dividing would give NaN."""
+    zeros = np.zeros(5)
+    assert np.array_equal(normalize_mono(zeros), zeros)
+
+
+def test_mono_centres_and_scales_by_the_larger_peak():
+    assert np.allclose(normalize_mono([0.0, 1.0, 2.0]), [-1.0, 0.0, 1.0])
+
+
+def test_mono_without_bias_removal_maps_the_range_onto_the_full_scale():
+    """remove_bias=False is an affine map of [min, max] onto [-1, 1], which
+    fills the range but stretches an asymmetric waveform."""
+    out = normalize_mono([0.0, 1.0, 4.0], remove_bias=False)
+    assert out.min() == pytest.approx(-1.0)
+    assert out.max() == pytest.approx(1.0)
+
+
+def test_stereo_all_zero_is_returned_untouched():
+    zeros = np.zeros((2, 4))
+    assert np.array_equal(normalize_stereo(zeros), zeros)
+
+
+def _stereo():
+    return np.vstack((np.array([0.0, 1.0, 2.0]),
+                      np.array([0.0, 0.5, 1.0])))
+
+
+def test_stereo_together_keeps_the_balance_between_channels():
+    """The default scales both channels by one factor, so the quieter
+    channel stays quieter."""
+    out = normalize_stereo(_stereo())
+    assert np.allclose(out[0], [-1.0, 0.0, 1.0])
+    assert np.allclose(out[1], [-0.5, 0.0, 0.5])
+
+
+def test_stereo_separately_brings_each_channel_to_full_scale():
+    """normalize_sep=True discards the balance, by design."""
+    out = normalize_stereo(_stereo(), normalize_sep=True)
+    assert np.allclose(out[0], [-1.0, 0.0, 1.0])
+    assert np.allclose(out[1], [-1.0, 0.0, 1.0])
+
+
+def test_stereo_without_bias_removal_maps_the_range():
+    out = normalize_stereo(_stereo(), remove_bias=False)
+    assert out.min() == pytest.approx(-1.0)
+    assert out.max() == pytest.approx(1.0)
+
+
+def test_stereo_without_bias_removal_separately():
+    out = normalize_stereo(_stereo(), remove_bias=False, normalize_sep=True)
+    for channel in out:
+        assert channel.min() == pytest.approx(-1.0)
+        assert channel.max() == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("remove_bias", [True, False])
+@pytest.mark.parametrize("normalize_sep", [True, False])
+def test_stereo_always_lands_inside_full_scale(remove_bias, normalize_sep):
+    rng = np.random.default_rng(0)
+    signal = np.vstack((rng.uniform(-3, 5, 64), rng.uniform(-1, 2, 64)))
+
+    out = normalize_stereo(signal, remove_bias=remove_bias,
+                           normalize_sep=normalize_sep)
+
+    assert out.min() >= -1.0 - 1e-12
+    assert out.max() <= 1.0 + 1e-12
+
+
+@pytest.mark.parametrize("value", [1.0, -3.0, 0.0])
+@pytest.mark.parametrize("remove_bias", [True, False])
+def test_a_constant_mono_signal_normalizes_to_silence(value, remove_bias):
+    """Regression: a constant signal has no dynamic range, so the scale
+    factor is zero and dividing by it filled the result with NaN. Only the
+    all-zero case was guarded."""
+    out = normalize_mono(np.full(5, value), remove_bias=remove_bias)
+    assert np.array_equal(out, np.zeros(5))
+
+
+@pytest.mark.parametrize("normalize_sep", [True, False])
+@pytest.mark.parametrize("remove_bias", [True, False])
+def test_a_constant_stereo_signal_normalizes_to_silence(normalize_sep,
+                                                        remove_bias):
+    out = normalize_stereo(np.ones((2, 4)), remove_bias=remove_bias,
+                           normalize_sep=normalize_sep)
+    assert np.array_equal(out, np.zeros((2, 4)))
+
+
+def test_one_flat_channel_does_not_poison_the_other():
+    """Normalizing separately, a silent channel must not make the live one
+    NaN."""
+    signal = np.vstack((np.ones(3), np.array([0.0, 1.0, 2.0])))
+    out = normalize_stereo(signal, normalize_sep=True)
+    assert np.array_equal(out[0], np.zeros(3))
+    assert np.allclose(out[1], [-1.0, 0.0, 1.0])
+
+
+def test_normalizing_never_produces_nan():
+    """The writers refuse NaN, so this is the last line before an error."""
+    rng = np.random.default_rng(0)
+    for signal in (np.ones(8), np.zeros(8), rng.uniform(-1, 1, 8),
+                   np.full(8, -2.5)):
+        assert np.isfinite(normalize_mono(signal)).all()
+        stereo = np.vstack((signal, signal))
+        assert np.isfinite(normalize_stereo(stereo)).all()

--- a/tests/test_remaining_paths.py
+++ b/tests/test_remaining_paths.py
@@ -1,0 +1,336 @@
+"""The last branches: alternative parameters and platform-specific paths."""
+
+import sys
+import types
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import music
+import music.singing.bootstrap as bootstrap
+import music.singing.paths as paths
+import music.singing.perform as perform
+from music.legacy.CanonicalSynth import CanonicalSynth, _fit
+from music.structures.peals.plain_changes import PlainChanges
+
+
+def _finite(a):
+    a = np.asarray(a)
+    return a.size > 0 and np.isfinite(a).all()
+
+
+# --------------------------------------------------------------------------
+# Sequencer
+# --------------------------------------------------------------------------
+
+def test_sequencer_renders_a_vibrato_note():
+    seq = music.Sequencer()
+    seq.add_note(440, start=0, duration=0.05, vibrato_freq=6,
+                 max_pitch_dev=2)
+    assert _finite(seq.render())
+
+
+def test_sequencer_applies_an_adsr_envelope():
+    seq = music.Sequencer()
+    seq.add_note(440, start=0, duration=0.05,
+                 adsr_params={"attack_duration": 5, "release_duration": 5})
+    assert _finite(seq.render())
+
+
+def test_sequencer_places_a_note_in_space_and_writes_stereo(tmp_path):
+    """A spatial note makes the render stereo, so write() takes the other
+    branch too."""
+    seq = music.Sequencer()
+    seq.add_note(440, start=0, duration=0.05, spatial={"x": 0.5, "y": 0.1})
+    rendered = seq.render()
+    assert rendered.ndim == 2
+
+    path = tmp_path / "seq.wav"
+    seq.write(str(path))
+    assert path.is_file()
+
+
+def test_sequencer_mixes_mono_and_stereo_notes_together():
+    """One spatial note and one plain one: the mixer has to promote."""
+    seq = music.Sequencer()
+    seq.add_note(440, start=0, duration=0.05)
+    seq.add_note(330, start=0.02, duration=0.05,
+                 spatial={"x": 0.5, "y": 0.1})
+    out = seq.render()
+    assert out.ndim == 2 and _finite(out)
+
+
+def test_sequencer_mixes_stereo_then_mono():
+    seq = music.Sequencer()
+    seq.add_note(440, start=0, duration=0.05, spatial={"x": 0.5, "y": 0.1})
+    seq.add_note(330, start=0.02, duration=0.05)
+    out = seq.render()
+    assert out.ndim == 2 and _finite(out)
+
+
+# --------------------------------------------------------------------------
+# Cache locations
+# --------------------------------------------------------------------------
+
+def _fake_os(name, environ):
+    """A stand-in for the `os` module as paths.py uses it.
+
+    Setting os.name globally is not an option: pathlib reads it to decide
+    which Path flavour to build, and asking for WindowsPath on a posix host
+    raises -- including inside pytest's own reporting.
+    """
+    return types.SimpleNamespace(name=name, environ=environ)
+
+
+def test_cache_root_on_linux(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(paths, "os", _fake_os("posix", {}))
+    assert paths._cache_root().name == ".cache"
+
+
+def test_cache_root_honours_xdg(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(paths, "os",
+                        _fake_os("posix", {"XDG_CACHE_HOME": str(tmp_path)}))
+    assert paths._cache_root() == tmp_path
+
+
+def test_cache_root_on_windows(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(paths, "os",
+                        _fake_os("nt", {"LOCALAPPDATA": str(tmp_path)}))
+    assert paths._cache_root() == tmp_path
+
+
+# --------------------------------------------------------------------------
+# Singing
+# --------------------------------------------------------------------------
+
+def test_make_test_song_sings_its_phrase():
+    """The engine cannot run here, so check what is handed to it."""
+    with patch.object(bootstrap, "sing", return_value=np.zeros(4)) as sing:
+        bootstrap.make_test_song()
+
+    text, notes, durs = sing.call_args[0]
+    assert len(text.split()) == len(notes) == len(durs)
+
+
+def test_sing_reports_a_missing_makefile(tmp_path, monkeypatch):
+    """The engine directory is valid but the copy fails anyway."""
+    engine = tmp_path / "engine"
+    (engine / "cache").mkdir(parents=True)
+    (engine / "Makefile").write_text("all:\n\ttrue\n")
+    monkeypatch.setenv(paths.ENV_VAR, str(engine))
+    monkeypatch.setattr(paths, "missing_requirements", lambda: [])
+    monkeypatch.setattr(perform, "write_abc", lambda *a, **k: None)
+
+    with patch.object(perform.shutil, "copy",
+                      side_effect=OSError("disk full")):
+        with pytest.raises(RuntimeError, match="Failed to prepare"):
+            perform.sing()
+
+
+# --------------------------------------------------------------------------
+# CanonicalSynth
+# --------------------------------------------------------------------------
+
+def test_fit_returns_nothing_for_a_zero_length_stage():
+    assert _fit(np.arange(10.0), 0).size == 0
+
+
+def test_synth_without_vibrato_or_tremolo():
+    """Regression: a depth of zero left the corresponding table as None,
+    and rawRender and tremoloEnvelope read them unconditionally, so
+    switching an effect off raised TypeError."""
+    synth = CanonicalSynth()
+    synth.synthSetup(vibrato_depth=0, tremolo_depth=0)
+
+    assert synth.vibrato is False
+    assert synth.tremolo is False
+    assert _finite(synth.rawRender(duration=0.05))
+    # A depth of zero is unity gain, not silence.
+    assert np.allclose(synth.tremoloEnvelope(duration=0.05), 1.0)
+
+
+def test_synth_still_modulates_with_its_defaults():
+    """The fix above must not have turned the effects off for everyone."""
+    synth = CanonicalSynth()
+    assert synth.vibrato is True and synth.tremolo is True
+    envelope = synth.tremoloEnvelope(duration=1.0, tremolo_frequency=4.0)
+    assert not np.allclose(envelope, 1.0)
+
+
+def test_adsr_with_a_note_rendered_during_setup():
+    """render_note=True makes adsrSetup return the shaped note itself."""
+    synth = CanonicalSynth()
+    out = synth.adsrSetup(render_note=True)
+    assert out is None or _finite(out)
+
+
+# --------------------------------------------------------------------------
+# Being
+# --------------------------------------------------------------------------
+
+def test_being_render_defaults_its_filename(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    being = music.Being()
+    being.f_ = [220.0, 330.0]
+    being.render(2, True)
+    assert (tmp_path / "abeing.wav").is_file()
+
+
+def test_being_render_appends_the_extension(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    being = music.Being()
+    being.f_ = [220.0]
+    being.render(1, "named")
+    assert (tmp_path / "named.wav").is_file()
+
+
+# --------------------------------------------------------------------------
+# Odds and ends
+# --------------------------------------------------------------------------
+
+def test_adsr_sized_by_a_number_of_samples():
+    """number_of_samples is the alternative to envelope_duration."""
+    assert len(music.adsr(number_of_samples=8820)) == 8820
+
+
+def test_perform_peal_builds_its_own_hunts_when_given_none():
+    peal = PlainChanges(3)
+    hunts = peal.perform_peal(3)
+    assert hunts is None or hunts
+
+
+def test_mix_pads_the_first_vector_when_it_is_shorter():
+    """The other leg of the length comparison."""
+    out = music.mix(np.ones(3), np.ones(6) * 2)
+    assert len(out) == 6
+    assert _finite(out)
+
+
+def test_tremolo_envelope_applied_to_a_sonic_vector():
+    """Regression: `if sonic_vector:` truth-tested the array and raised,
+    although the return statement below it uses `is not None`."""
+    synth = CanonicalSynth()
+    signal = np.ones(500)
+
+    shaped = synth.tremoloEnvelope(sonic_vector=signal)
+
+    assert shaped.shape == signal.shape
+    assert _finite(shaped)
+    assert not np.allclose(shaped, signal)
+
+
+@pytest.mark.parametrize("theta", [-70, 70])
+def test_localize2_brute_across_both_sides(theta):
+    """The brute method delays whichever ear is further away, so the sign
+    of theta picks the branch."""
+    with pytest.warns(UserWarning, match="long time"):
+        out = music.localize2(sonic_vector=np.ones(2048), theta=theta,
+                              method="brute")
+    assert out.shape[0] == 2 and _finite(out)
+
+
+def test_mix_stereo_pads_the_first_vector_at_the_end():
+    """end=True with the *second* vector longer is the remaining corner."""
+    out = music.mix_stereo(np.ones(3), np.ones(6) * 2, end=True)
+    assert out.shape == (2, 6)
+    assert _finite(out)
+
+
+@pytest.mark.parametrize("function", [
+    music.note_with_vibrato_seq_localization,
+    music.note_with_vibratos_glissandos,
+])
+def test_sequenced_notes_take_the_curved_transitions(function):
+    """The nested `alpha` chooses the expression used for each transition:
+    != 1 curves a pitch glide, and 0 on a vibrato drops its exponent. The
+    defaults are all ones, so neither branch was ever reached.
+
+    The shapes are deeply nested and must agree with the other arguments,
+    so the default is reshaped rather than rebuilt.
+    """
+    import inspect
+
+    default = inspect.signature(function).parameters["alpha"].default
+    # First row: the pitch transitions. The rest: the vibratos.
+    alpha = tuple(
+        tuple(2.0 if row == 0 else 0 for _ in values)
+        for row, values in enumerate(default)
+    )
+
+    out = function(alpha=alpha)
+
+    assert _finite(out)
+
+
+@pytest.mark.parametrize("theta", [70, -70])
+def test_localize2_brute_synthesizes_each_partial(theta):
+    """The brute method rebuilds the signal one sinusoid at a time, so it
+    needs a spread spectrum to have anything to iterate over: a constant
+    signal is a single DC bin and the loop body never runs.
+
+    A positive theta puts the source to the left, which swaps which ear is
+    amplified and which is delayed.
+    """
+    rng = np.random.default_rng(0)
+    noise = rng.uniform(-1, 1, 256)
+
+    with pytest.warns(UserWarning, match="long time"):
+        out = music.localize2(sonic_vector=noise, theta=theta,
+                              method="brute")
+
+    assert out.shape[0] == 2
+    assert _finite(out)
+
+
+def test_localize2_ifft_with_a_wide_spectrum():
+    """A spectrum reaching past 4 kHz picks the shorter interaural delay
+    constant."""
+    rng = np.random.default_rng(1)
+    out = music.localize2(sonic_vector=rng.uniform(-1, 1, 4096), theta=45)
+    assert out.shape[0] == 2 and _finite(out)
+
+
+def test_seq_localization_curves_its_position_transitions():
+    """`method` chooses how the source moves between positions, and alpha
+    curves an exponential move. A positive first x also picks the other
+    channel-padding branch."""
+    out = music.note_with_vibrato_seq_localization(
+        x=(10, 8, 5, 3), y=(1, 1, .1, .1),
+        alpha=((1, 1), (1, 1, 1), (1, 1, 1, 1, 1), (2.0, 2.0, 2.0)),
+        method=("exp", "exp", "exp"),
+    )
+    assert out.shape[0] == 2 and _finite(out)
+
+
+@pytest.mark.parametrize("stereo", [True, False])
+def test_an_exponential_path_may_not_cross_the_listener(stereo):
+    """Regression: the transition is `start * (end / start) ** curve`, and
+    a negative base raised to a fractional power is not a real number. A
+    source moving from one side to the other produced NaN audio -- 352798
+    samples of it -- rather than an error."""
+    with pytest.raises(ValueError, match="cannot run from"):
+        music.note_with_vibrato_seq_localization(
+            x=(10, -10, 5, 3), method=("exp", "exp", "exp"), stereo=stereo
+        )
+
+
+def test_a_linear_path_may_cross_the_listener():
+    """`lin` has no such restriction, and the defaults rely on it."""
+    out = music.note_with_vibrato_seq_localization(
+        x=(-10, 10, 5, 3), method=("lin", "lin", "lin")
+    )
+    assert _finite(out)
+
+
+def test_seq_localization_curves_its_path_in_mono_too():
+    """The mono branch has its own copy of the position loop."""
+    out = music.note_with_vibrato_seq_localization(
+        x=(10, 8, 5, 3), y=(1, 1, .1, .1),
+        alpha=((1, 1), (1, 1, 1), (1, 1, 1, 1, 1), (2.0, 2.0, 2.0)),
+        method=("exp", "exp", "exp"), stereo=False,
+    )
+    assert out.ndim == 1 and _finite(out)

--- a/tests/test_remaining_paths.py
+++ b/tests/test_remaining_paths.py
@@ -2,6 +2,7 @@
 
 import sys
 import types
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -81,6 +82,14 @@ def _fake_os(name, environ):
     raises -- including inside pytest's own reporting.
     """
     return types.SimpleNamespace(name=name, environ=environ)
+
+
+def test_cache_root_on_macos(monkeypatch):
+    """Patched rather than left to the host: otherwise this branch is only
+    covered when the tests happen to run on a Mac, and the Linux and
+    Windows ones only when they do not."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert paths._cache_root() == Path.home() / "Library" / "Caches"
 
 
 def test_cache_root_on_linux(monkeypatch):

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -246,3 +246,22 @@ def test_unimplemented_peals_say_so(method):
     """These are honest placeholders; keep them honest."""
     with pytest.raises(NotImplementedError):
         getattr(music.Peals(), method)()
+
+
+def test_print_peal_writes_a_coloured_row_per_permutation(capsys):
+    """It colours the hunted positions and prints one line per row."""
+    peal = [[0, 1, 2], [1, 0, 2], [1, 2, 0]]
+
+    music.print_peal(peal, hunts=[0])
+
+    printed = capsys.readouterr().out
+    # one line per row, plus print()'s own trailing newline
+    assert printed.count("\n") == len(peal) + 1
+    for row in peal:
+        for element in row:
+            assert str(element) in printed
+
+
+def test_print_peal_defaults_to_hunting_the_first_two(capsys):
+    music.print_peal([[0, 1, 2]])
+    assert capsys.readouterr().out.strip()

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -36,3 +36,21 @@ def test_primary_tables_delegates_to_the_one_generator(kind, attribute):
     """There used to be three copies of these four definitions."""
     pt = PrimaryTables(size=256)
     assert np.array_equal(getattr(pt, attribute), waveform_table(kind, 256))
+
+
+def test_draw_tables_plots_all_four(monkeypatch):
+    """draw_tables is a convenience for looking at the tables; check it
+    reaches the plotting calls rather than opening a window."""
+    import music.tables as tables_module
+
+    plotted, shown = [], []
+    monkeypatch.setattr(tables_module.p, "plot",
+                        lambda data, *a, **k: plotted.append(len(data)))
+    monkeypatch.setattr(tables_module.p, "xlim", lambda *a, **k: None)
+    monkeypatch.setattr(tables_module.p, "ylim", lambda *a, **k: None)
+    monkeypatch.setattr(tables_module.p, "show", lambda: shown.append(True))
+
+    PrimaryTables(size=32).draw_tables()
+
+    assert plotted == [32, 32, 32, 32]
+    assert shown == [True]


### PR DESCRIPTION
Coverage goes **85% → 100%**, enforced in CI. The number was never the point:
**every one of the ten defects below was sitting behind a branch the suite had
never taken.**

## Two functions truth-tested an array

`pan_transitions()` and `CanonicalSynth.tremoloEnvelope()` both did
`if sonic_vector:`, which raises *"the truth value of an array with more than
one element is ambiguous"*. Both have a correct `is not None` check **elsewhere
in the same function**.

## …and behind one of them, another

`pan_transitions` calls `mix_with_offset`, whose stereo path passed
`['s1', 's2']` to `resolve_stereo` — parameter names renamed long ago — and
raised `KeyError`. So that feature was broken twice over.

## The rest

| where | what |
|---|---|
| `mix_stereo` | tested for stereo with `len(x) != 2`, so a **two-sample mono** vector was taken for a channel pair and its "channels" indexed as scalars |
| `mix_with_offset_` | rejected tuples via an exact `type()` check — the same idiom swept earlier, in a spelling that sweep missed |
| `localize2` | raised for **every odd-length input**: the conjugate mirror ran to `max_coef`, which only balances for an even length |
| `normalize_mono` / `normalize_stereo` | returned **NaN for any constant signal** — only all-zero was guarded, and a constant is silence once its offset is removed |
| `PlainChanges.peals` | never populated, so `act_all()` could not run on the class that builds two peals |
| `Being.walk` | `UnboundLocalError` for an unrecognised method |
| `Being.setPar` | a silent no-op for anything but `'f'` |
| `CanonicalSynth.synthSetup` | left the vibrato/tremolo tables as `None` when the effect was off, though both are read unconditionally — so **switching an effect off raised `TypeError`** |

Plus: an **exponential position transition across the listener produced NaN
audio**. `start * (end / start) ** curve` has a negative base when the source
changes sides, and a fractional power of that is not a real number — 352,798
NaN samples. It now raises, naming `'lin'` as the method for a crossing path.

The `normalize_*` NaN is worth singling out: it surfaced *because* the WAV
writers now refuse NaN, which turned a corrupt file into an error. That guard,
added a few PRs ago, earned its keep here.

## One line is genuinely unreachable

The Nyquist-bin case in `localize2`'s brute method: the loop runs to
`ncoeffs - 1` and `ncoeffs <= int(lambda_l / 2)`, so `i` never reaches
`lambda_l / 2`. Marked `# pragma: no cover` with the reasoning, rather than
deleted, in case that bound is ever widened.

## Tests

Six new modules, all covering the *alternative* branches of parametrised
routines — both channel modes, each `method`, each curve, each error path:

`test_mixing.py`, `test_normalization.py`, `test_abc_notation.py`,
`test_io_paths.py`, `test_branches.py`, `test_remaining_paths.py`.

`test_abc_notation.py` is worth a look: the singing engine is a Perl program
that cannot run in CI, but everything the package does *before* handing over —
semitones to ABC pitch names, durations, the `.abc` header — is pure string
generation, and now asserted against real expected output.

**260 → 441 tests.** Floor raised 80% → 100%.

## Verification

Clean clone, `pip install -e '.[dev,docs]'`, `MUSIC_ECANTORIX_DIR` pointing
nowhere: ruff clean, mypy clean on 3.10 / 3.11 / 3.12, 441 tests at 100%
coverage, docs build with `-W`. 9 of 10 examples run clean, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
