### PR TITLE
Stop normalize_stereo corrupting a mono vector, and tidy two examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ version will not be byte-identical to one from 1.0.1:
    boxcar average instead of the identity.
 
 ### Fixed
+- `normalize_stereo()` corrupted a mono vector instead of rejecting or
+  promoting it. A one-dimensional array had its first two *samples* read as
+  the two channels, and since the mean of a scalar is itself, both were
+  silently zeroed and the rest scaled by the wrong factor. It now gives a
+  mono vector two identical channels, so `write_wav_stereo(mono)` produces a
+  genuine stereo file rather than a damaged mono one.
 - Nine defects that only appeared once every branch was exercised:
   - `pan_transitions()` and `CanonicalSynth.tremoloEnvelope()` truth-tested
     their `sonic_vector`, so passing one raised "the truth value of an array
@@ -165,6 +171,14 @@ version will not be byte-identical to one from 1.0.1:
   exactly representable levels survive a round trip unchanged.
 
 ### Changed
+- `examples/noisy.py` said it wrote "a pentatonic scale with different
+  effects"; it writes noises. Its separator beep is now shaped by an ADSR
+  envelope, which is what the separator wanted anyway -- a raw note clicks at
+  both ends -- and it writes the same note with and without the envelope so
+  the difference can be heard on its own.
+- `examples/chromatic_scale.py` gains the generated-scale alternative as a
+  comment, starting from the C4 the listed scale starts on rather than from
+  A4.
 - The README is rewritten for the PyPI landing page it becomes. It opened with
   six shell blocks and no Python: the first code a visitor met was the Roadmap
   at line 128, showing an API that does not exist. It now opens with a working

--- a/examples/chromatic_scale.py
+++ b/examples/chromatic_scale.py
@@ -16,6 +16,7 @@ scale = [
     466.16,  # A#4
     493.88   # B4
 ]
+# or, from the same C4: [261.63 * 2 ** (i / 12) for i in range(12)]
 
 sonic_vector = []
 

--- a/examples/noisy.py
+++ b/examples/noisy.py
@@ -1,5 +1,5 @@
-""" Simple script that writes a pentatonic scale on a WAV file
-    with different effects.
+""" Simple script that writes a sequence of noises into a WAV file,
+    each separated by a short beep.
 """
 
 import music
@@ -7,7 +7,11 @@ import music
 noises = ['brown', 'pink', 'white', 'blue', 'violet', 'black']
 sonic_vector = []
 silence = music.core.synths.silence(duration=0.4)
-beep = music.core.synths.note(duration=0.1)
+
+# A note starts and stops abruptly, which clicks. An ADSR envelope fades it
+# in and out, so it makes a cleaner separator between the noises.
+beep = music.adsr(sonic_vector=music.core.synths.note(duration=0.1),
+                  attack_duration=10, release_duration=20)
 
 for noise in noises:
     sonic_vector.append(music.core.synths.noises.noise(noise_type=noise))
@@ -18,5 +22,12 @@ for noise in noises:
 sonic_vector.append(music.core.synths.noises.gaussian_noise())
 
 stack = music.utils.horizontal_stack(*sonic_vector)
-music.core.io.write_wav_stereo(sonic_vector=stack,
-                               filename='noisy.wav')
+music.core.io.write_wav_mono(sonic_vector=stack,
+                             filename='noisy.wav')
+
+# The same note with and without the envelope, to hear what it does on its
+# own: the plain one clicks at both ends, the shaped one does not.
+plain = music.core.synths.note(duration=1)
+shaped = music.adsr(sonic_vector=plain)
+music.core.io.write_wav_mono(sonic_vector=plain, filename='beep_plain.wav')
+music.core.io.write_wav_mono(sonic_vector=shaped, filename='beep_shaped.wav')

--- a/music/core/functions.py
+++ b/music/core/functions.py
@@ -63,7 +63,8 @@ def normalize_stereo(sonic_vector, remove_bias=True, normalize_sep=False):
     Parameters
     ----------
     sonic_vector : array_like
-        A (2, nsamples) shaped array.
+        A (2, nsamples) shaped array. A one-dimensional array is taken as
+        mono and given two identical channels.
     remove_bias : boolean
         Whether to remove or not the bias (or offset)
     normalize_sep : boolean
@@ -78,6 +79,12 @@ def normalize_stereo(sonic_vector, remove_bias=True, normalize_sep=False):
 
     """
     sv_copy = np.array(sonic_vector, dtype=np.float64)
+    if sv_copy.ndim == 1:
+        # A mono vector: give it two identical channels. Indexing it as
+        # though it were a channel pair read its first two *samples* as the
+        # channels, and since the mean of a scalar is itself, silently
+        # zeroed them.
+        sv_copy = np.vstack((sv_copy, sv_copy))
     if sv_copy.max() == sv_copy.min():
         # Constant, including all-zero: silence once the offset is gone.
         return np.zeros_like(sv_copy)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -115,3 +115,29 @@ def test_normalizing_never_produces_nan():
         assert np.isfinite(normalize_mono(signal)).all()
         stereo = np.vstack((signal, signal))
         assert np.isfinite(normalize_stereo(stereo)).all()
+
+
+def test_a_mono_vector_given_to_the_stereo_normalizer_is_promoted():
+    """Regression: a 1-D array had its first two *samples* read as the two
+    channels. The mean of a scalar is itself, so those two samples were
+    silently zeroed and the rest scaled wrongly."""
+    signal = np.array([0.5, -0.3, 0.9, -0.7, 0.2])
+
+    out = normalize_stereo(signal)
+
+    assert out.shape == (2, len(signal))
+    assert np.array_equal(out[0], out[1])
+    assert np.allclose(out[0], normalize_mono(signal))
+
+
+def test_the_stereo_writer_accepts_a_mono_vector(tmp_path):
+    """It writes a genuine stereo file rather than a corrupted mono one."""
+    import music
+
+    tone = music.note(440, 0.05)
+    path = tmp_path / "mono_in.wav"
+    music.write_wav_stereo(tone, filename=str(path))
+
+    restored = music.read_wav(str(path))
+    assert restored.shape[0] == 2
+    assert np.allclose(restored[0], restored[1])


### PR DESCRIPTION
Two example files, and the bug one of them was quietly sitting on.

## The bug

`examples/noisy.py` passed mono arrays to `write_wav_stereo`. That looked
harmless. It was not: `normalize_stereo` indexes its input as `[0]` and `[1]`
to get the channels, so a **one-dimensional array had its first two *samples*
read as the channels**. The mean of a scalar is itself, so `x - x.mean()` made
both zero, and the remainder was scaled by a factor derived from them:

```
normalize_stereo([0.5, -0.3, 0.9, -0.7, 0.2])
             ->  [0.0,  0.0,  1.0, -0.7778, 0.2222]
```

A mono vector now gets two identical channels, so `write_wav_stereo(mono)`
writes a genuine stereo file instead of a damaged mono one.

**`noisy.py` was the only caller affected** — the other four examples that
write stereo all pass `(2, n)` already. I checked each before changing
anything.

## `chromatic_scale.py`

The generated-scale alternative, with the starting note corrected.
`440 * 2 ** (i / 12)` begins at **A4** and runs to G#5, while the list it is
offered as an alternative to runs **C4 to B4** — a difference of up to 337 Hz.
From `261.63` it matches the listed frequencies to 0.012 Hz.

## `noisy.py`

Its docstring claimed it wrote *"a pentatonic scale with different effects"*.
It writes noises.

The separator beep is now shaped by an ADSR envelope, which is what a
separator wants — a raw note clicks at both ends. That makes the added
raw-versus-shaped comparison part of the file rather than something sitting
beside it, and both are written under names that say which is which
(`beep_plain.wav`, `beep_shaped.wav`), through `write_wav_mono`, the function
that matches the content.

Verified the comment is true: the plain note starts at amplitude 1.000, the
shaped one at 0.000.

## Verification

Clean clone: ruff clean, mypy clean on 3.10 / 3.11 / 3.12, **478 tests at 100%
coverage**, docs build with `-W`. All ten examples run; `singing_demo` still
needs the external eCantorix engine, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
