### PR TITLE
Add CITATION.cff, and set the repo description, homepage and topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,10 @@ version will not be byte-identical to one from 1.0.1:
   [-1, 1]), and removed a stray duplicate entry from the Returns section.
 
 ### Added
+- `CITATION.cff`, so GitHub renders a "Cite this repository" button and the
+  request the README makes in prose becomes something a tool can act on. It
+  names the package as the software and the MASS article as the preferred
+  citation, which is what the documentation asks people to cite.
 - Sphinx documentation, published to GitHub Pages from `master`. The
   reference groups all 69 exports by role rather than alphabetically, and CI
   builds it with `-W`, so a malformed docstring fails rather than rendering

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,50 @@
+cff-version: 1.2.0
+title: music
+message: >-
+  If you use this package, please cite the article under
+  preferred-citation, as the documentation asks.
+type: software
+version: 1.1.0
+date-released: '2026-08-29'
+license: MIT
+repository-code: https://github.com/ttm/music
+url: https://ttm.github.io/music/
+abstract: >-
+  Extreme-fidelity synthesis of musical elements, based on the MASS
+  framework: psychophysical descriptions of musical elements in LPCM
+  audio, expressed as equations and corresponding Python routines.
+  State is updated at every sample, so a rendered sound is as close as
+  it can be to the mathematical model that describes it.
+keywords:
+  - audio
+  - synthesis
+  - psychoacoustics
+  - signal processing
+  - sonification
+  - change ringing
+  - MASS
+authors:
+  - family-names: Fabbri
+    given-names: Renato
+    email: renato.fabbri@gmail.com
+  - family-names: Donati
+    given-names: Jacopo
+preferred-citation:
+  type: article
+  title: Musical elements in the discrete-time representation of sound
+  year: '2017'
+  url: https://arxiv.org/abs/1412.6853
+  notes: arXiv preprint arXiv:1412.6853
+  authors:
+    - family-names: Fabbri
+      given-names: Renato
+    - family-names: Vieira da Silva
+      given-names: Vilson
+      name-suffix: Junior
+    - family-names: Pessotti
+      given-names: Antônio Carlos Silvano
+    - family-names: Corrêa
+      given-names: Débora Cristina
+    - family-names: Oliveira
+      given-names: Osvaldo Novais
+      name-suffix: Jr.


### PR DESCRIPTION
Closes the last item of #71 that lives in the repository. The other three were
settings changes and are already applied — see below.

## `CITATION.cff`

The README asks to be cited, and GitHub renders a **"Cite this repository"**
button when this file exists, so the request stops being prose a reader has to
act on by hand.

It names the package as the software and the **MASS article as the preferred
citation**, which is what the documentation actually asks people to cite.

The article's metadata comes from arXiv rather than the abbreviated form in the
docstrings — which turned out to matter:

- **Five authors**, not the "Fabbri, Renato, et al." the docstrings carry:
  Fabbri; Vieira da Silva Junior; Pessotti; Corrêa; Oliveira Jr.
- **2017 is the date of v2.** The original submission is 22 Dec 2014, and v2 is
  26 Oct 2017 — which is why the README says 2017 and why that is right.

Validates against CFF schema 1.2.0 (`cffconvert --validate`), and renders as:

```
Fabbri R., Donati J. (2026). music (version 1.1.0).
URL: https://ttm.github.io/music/
```

### One thing worth your eye

**The author name splitting.** Brazilian compound surnames do not map cleanly
onto CFF's `given-names` / `family-names` / `name-suffix`, and I only had
arXiv's own split to go on. I have used:

| arXiv | CFF |
|---|---|
| `Junior, Vilson Vieira da Silva` | given `Vilson`, family `Vieira da Silva`, suffix `Junior` |
| `Oliveira Jr, Osvaldo N.` | given `Osvaldo Novais`, family `Oliveira`, suffix `Jr.` |

Both are my best reading, not something I could verify — there is no BibTeX in
the MASS repository to check against. Please correct them if wrong; they are
the two lines most likely to need it.

## Already applied (repo settings, not in this diff)

- **Description** set to *"Extreme-fidelity synthesis of musical elements,
  based on the MASS framework"*, matching `pyproject.toml` and PyPI
- **Homepage** set to https://ttm.github.io/music/, so the docs appear in the
  sidebar
- **19 topics** added, where there were none: `python`, `audio`, `music`,
  `synthesis`, `sound-synthesis`, `dsp`, `signal-processing`,
  `audio-processing`, `psychoacoustics`, `psychophysics`, `sonification`,
  `data-sonification`, `change-ringing`, `campanology`, `music-composition`,
  `additive-synthesis`, `binaural`, `numpy`, `wav`

`change-ringing` and `campanology` are there deliberately: that part of the
package has almost no competition in Python, and nobody was going to find it
under "audio".

## Left open on #71

Zenodo (best set up before the next release, so it catches one) and a tutorial
page for the docs site. Both are more than a settings change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
