### PR TITLE
Record the Zenodo DOI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,11 @@ version will not be byte-identical to one from 1.0.1:
   [-1, 1]), and removed a stray duplicate entry from the Returns section.
 
 ### Added
+- A DOI. Every release is archived on Zenodo from now on;
+  [10.5281/zenodo.22151793](https://doi.org/10.5281/zenodo.22151793) resolves
+  to the most recent one, and 1.1.0 specifically is
+  [10.5281/zenodo.22151794](https://doi.org/10.5281/zenodo.22151794). Both are
+  recorded in `CITATION.cff`.
 - A [tutorial](https://ttm.github.io/music/tutorial.html) in the documentation,
   walking from a single note to a short stereo piece: what the arrays are, the
   units each parameter is expressed in, and a measurement showing that a

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,14 @@ version: 1.1.0
 date-released: '2026-08-29'
 license: MIT
 repository-code: https://github.com/ttm/music
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.22151793
+    description: >-
+      Concept DOI, resolving to the most recent release of the software.
+  - type: doi
+    value: 10.5281/zenodo.22151794
+    description: Archived snapshot of version 1.1.0.
 url: https://ttm.github.io/music/
 abstract: >-
   Extreme-fidelity synthesis of musical elements, based on the MASS

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/ttm/music/actions/workflows/ci.yml/badge.svg)](https://github.com/ttm/music/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-ttm.github.io%2Fmusic-blue.svg)](https://ttm.github.io/music/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/ttm/music/blob/master/LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22151793.svg)](https://doi.org/10.5281/zenodo.22151793)
 
 **Extreme-fidelity synthesis of musical elements.**
 
@@ -47,6 +48,12 @@ linked social data, and with the [audiovisual analytics vocabulary and ontology
 To understand the routines further, read
 [Musical elements in the discrete-time representation of sound](https://github.com/ttm/mass/raw/master/doc/article.pdf).
 **If you use this package, please cite that article.**
+
+Every release is archived on Zenodo, so a specific version can be cited too:
+[10.5281/zenodo.22151793](https://doi.org/10.5281/zenodo.22151793) always
+resolves to the newest one. GitHub's *Cite this repository* button reads
+[CITATION.cff](https://github.com/ttm/music/blob/master/CITATION.cff) and
+gives you both, formatted.
 
 ## How to install
 


### PR DESCRIPTION
Zenodo archived the 1.1.0 release and minted two DOIs:

| | |
|---|---|
| **Concept** `10.5281/zenodo.22151793` | always resolves to the newest release |
| **Version** `10.5281/zenodo.22151794` | the 1.1.0 snapshot |

- `CITATION.cff` gains an `identifiers:` block with both, so the *Cite this repository* button offers them. Still validates against CFF 1.2.0.
- README gains a DOI badge (the concept DOI) and a sentence next to the existing request to cite the article, distinguishing citing the *software* from citing the *article*.
- Changelog records both.

## Known wart on the 1.1.0 deposit

Zenodo built that record's metadata from GitHub, not from `CITATION.cff` — creators came out as `rfabbri` and `Apo`, with no keywords. The cause is that `v1.1.0` tags `4f69588`, the commit the published sdist was actually built from, and `CITATION.cff` landed two commits later. Tagging the real release commit was the right call for reproducibility; this was its price.

It is fixable only in Zenodo's own UI (metadata of a published record is editable by its owner) — see the conversation for the exact values. **Every future release will pick up `CITATION.cff` automatically**, since it is now in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)