### PR TITLE
Sync the Zenodo record through its API instead of by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -e '.[dev]'
 
       - name: Lint
-        run: ruff check music tests examples conftest.py
+        run: ruff check music tests examples tools conftest.py
 
       - name: Type check
         run: mypy music

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,7 +6,8 @@
   "creators": [
     {
       "name": "Fabbri, Renato",
-      "affiliation": "BioSynCare.com, IFSC-USP, Juntadados, Nós Digitais, CDTL, ICMC/USP"
+      "affiliation": "BioSynCare.com, IFSC-USP, Juntadados, Nós Digitais, CDTL, ICMC/USP",
+      "orcid": "0000-0002-9699-629X"
     }
   ],
   "contributors": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ because the page PyPI shows can only be refreshed by an upload, and the
   EuroSciVoc terms -- each identified by its vocabulary's own URI, so the
   linked subjects survive a release rather than being retyped into the
   interface each time.
-- `RELEASING.md`, a checklist, including how to verify that those subjects
-  really did come across (Zenodo's own record endpoint does not report them;
-  the DataCite export does).
+- `tools/zenodo_sync.py`, which pushes `.zenodo.json` onto a published Zenodo
+  record through its API -- edit, update, publish, DOI unchanged. It resolves
+  each controlled term to the identifier Zenodo knows it by and insists on an
+  exact match, so the linked subjects no longer depend on whether the
+  release-time ingestion honours them, and a record edited by hand can always
+  be brought back in line with the file. Standard library only, and it needs
+  no token to show what it would send.
+- `RELEASING.md`, a checklist, including how to verify what actually landed
+  (Zenodo's own record endpoint does not report subjects at all; the DataCite
+  export does).
 - `Documentation`, `Tutorial`, `Source` and `Changelog` links in the project
   metadata, which PyPI shows in its sidebar. There had been only `Homepage`,
   pointing at the repository, and `Issues`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -41,6 +41,7 @@ authors:
   - family-names: Fabbri
     given-names: Renato
     email: renato.fabbri@gmail.com
+    orcid: 'https://orcid.org/0000-0002-9699-629X'
 preferred-citation:
   type: article
   title: Musical elements in the discrete-time representation of sound

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ pip install -e '.[dev,docs]'
 ```console
 pytest                                       # 481 tests, 100% coverage
 mypy music                                   # type check
-ruff check music tests examples conftest.py  # lint, at PEP 8's 79 columns
+ruff check music tests examples tools conftest.py  # lint, at PEP 8's 79 columns
 sphinx-build -b html -W docs docs/_build/html
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,17 +32,33 @@ Publishing the GitHub release is what triggers Zenodo. It archives the
 tarball and mints a version DOI under the existing concept DOI
 [10.5281/zenodo.22151793](https://doi.org/10.5281/zenodo.22151793).
 
-## After: check the Zenodo record
+## After: sync the Zenodo record
 
-Zenodo builds each new deposit from `.zenodo.json`, so the title, the author,
-Jacopo Donati as a contributor, the description, the keywords and the
-controlled-vocabulary subjects should all come across without anyone touching
-the interface.
+Zenodo builds each new deposit from `.zenodo.json` when the release is
+published, but do not rely on that alone: whether its ingestion honours the
+`subjects` block -- the controlled-vocabulary terms, as opposed to the
+free-text keywords -- is not something we control, and a record corrected by
+hand drifts from the file the moment anyone edits it.
 
-The `subjects` block is the part to verify, because it is the part that could
-silently do nothing: Zenodo's legacy metadata schema accepts
-`{term, scheme, identifier}` entries, but whether its GitHub ingestion honours
-them was established at 1.1.1 and not before. Check with:
+Push the file onto the record instead:
+
+```console
+python tools/zenodo_sync.py            # show what it would send
+python tools/zenodo_sync.py --write    # apply it
+```
+
+It resolves each controlled term to the identifier Zenodo knows it by,
+insisting on an exact match rather than accepting the nearest suggestion, then
+edits, updates and republishes the record. **The DOI does not change.** By
+default it targets the newest version under the concept DOI; `--record ID`
+overrides that.
+
+`--write` needs a token with the `deposit:write` and `deposit:actions` scopes,
+from https://zenodo.org/account/settings/applications/tokens/new/, in
+`ZENODO_TOKEN`. Reading needs none.
+
+Verify afterwards with the DataCite export rather than the record endpoint,
+which omits subjects entirely and will make a fully keyworded record look bare:
 
 ```console
 curl -sL https://zenodo.org/records/<id>/export/datacite-json \
@@ -50,23 +66,15 @@ curl -sL https://zenodo.org/records/<id>/export/datacite-json \
 ```
 
 Entries carrying a `subjectScheme` are linked to their vocabulary; entries
-without one are free text. If the MeSH, GEMET and EuroSciVoc terms come back
-without a scheme, or not at all, the ingestion ignored the block, and they
-have to be re-added by hand: open the record, **Edit**, type the term under
-*Keywords and subjects*, and pick the suggestion carrying the vocabulary
-prefix. Then **Publish**; the DOI does not change.
+without one are free text.
 
-Two traps in that interface, both of which have caught us:
+Two traps in Zenodo's web interface, if you edit there instead. Both have
+caught us, and both are why the script exists:
 
 - **Names are entered family-name-first.** A contributor typed as
   `Jacopo, Donati` has "Jacopo" recorded as the family name.
 - **Edits are not live until Publish is pressed.** A record can sit with a
   draft full of changes while the public page still shows the old metadata.
-
-One quirk worth knowing when checking: Zenodo's own
-`/api/records/<id>` endpoint omits `subjects` entirely, so a record can look
-unkeyworded there while the DataCite export and the web page both show the
-full set. Trust the export.
 
 ## Not part of the release
 

--- a/tools/zenodo_sync.py
+++ b/tools/zenodo_sync.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Push ``.zenodo.json`` onto a published Zenodo record.
+
+Zenodo builds each deposit from the repository when a release is
+published, but two things make that insufficient on its own.  Its
+ingestion may or may not honour the ``subjects`` block -- the
+controlled-vocabulary terms, as opposed to the free-text keywords -- and
+a record whose metadata was corrected by hand has no way to be brought
+back in line with the file short of retyping it.
+
+This script closes both gaps.  It reads ``.zenodo.json``, translates it
+into the record metadata Zenodo's REST API expects, and writes it to a
+published record: edit, update, publish.  The DOI does not change.
+
+Run it after a release, or any time ``.zenodo.json`` changes and the
+record should follow.
+
+Usage
+-----
+::
+
+    python tools/zenodo_sync.py                  # show what would change
+    python tools/zenodo_sync.py --write          # apply it
+
+``--write`` needs a personal access token with the ``deposit:write`` and
+``deposit:actions`` scopes, created at
+https://zenodo.org/account/settings/applications/tokens/new/ and passed
+in the ``ZENODO_TOKEN`` environment variable.  Reading needs no token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+#: The concept DOI, which always resolves to the newest version.
+CONCEPT_RECORD = "22151793"
+
+BASE = "https://zenodo.org/api"
+
+#: Zenodo names contributor roles in lowercase; ``.zenodo.json`` uses the
+#: capitalised form its own documentation shows.
+ROLE_IDS = {
+    "contactperson", "datacollector", "datacurator", "datamanager",
+    "distributor", "editor", "hostinginstitution", "producer",
+    "projectleader", "projectmanager", "projectmember", "registrationagency",
+    "registrationauthority", "relatedperson", "researcher", "researchgroup",
+    "rightsholder", "supervisor", "sponsor", "workpackageleader", "other",
+}
+
+
+class SyncError(RuntimeError):
+    """Something went wrong that the caller should see, not a traceback."""
+
+
+def ssl_context():
+    """A context that can verify zenodo.org.
+
+    A Python installed from python.org on macOS ships without a CA
+    bundle wired in, and every HTTPS call fails with
+    CERTIFICATE_VERIFY_FAILED until its Install Certificates command has
+    been run.  ``certifi`` is installed alongside it either way, so
+    prefer that and leave the platform default as the fallback.
+    """
+    try:
+        import certifi
+    except ImportError:
+        return ssl.create_default_context()
+    return ssl.create_default_context(cafile=certifi.where())
+
+
+def request(path, *, method="GET", payload=None, token=None):
+    """Call the Zenodo API and return the decoded body, or None."""
+    url = path if path.startswith("http") else f"{BASE}{path}"
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, headers=headers,
+                                 method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=60,
+                                    context=ssl_context()) as response:
+            body = response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", "replace")[:800]
+        raise SyncError(
+            f"{method} {url} -> HTTP {error.code}\n{detail}") from None
+    except urllib.error.URLError as error:
+        raise SyncError(f"{method} {url} -> {error.reason}") from None
+    return json.loads(body) if body else None
+
+
+# ---------------------------------------------------------------------
+# Translating .zenodo.json into what the API wants
+# ---------------------------------------------------------------------
+
+def split_name(name):
+    """Split ``"Family, Given"`` the way Zenodo's own interface reads it.
+
+    The interface takes the family name first, which is not obvious from
+    looking at it, and a name typed the other way round is silently
+    recorded with the given name as the surname.  Doing the split here
+    means the file is the only place it can go wrong.
+    """
+    family, _, given = (part.strip() for part in name.partition(","))
+    return family, given
+
+
+def as_person(entry, *, default_role=None):
+    """One creator or contributor, in the API's shape."""
+    family, given = split_name(entry["name"])
+    person = {"type": "personal", "family_name": family}
+    if given:
+        person["given_name"] = given
+    if entry.get("orcid"):
+        person["identifiers"] = [{"scheme": "orcid",
+                                  "identifier": entry["orcid"]}]
+
+    out = {"person_or_org": person}
+    if entry.get("affiliation"):
+        out["affiliations"] = [{"name": entry["affiliation"]}]
+
+    role = (entry.get("type") or default_role or "").lower()
+    if role:
+        if role not in ROLE_IDS:
+            raise SyncError(f"unknown contributor role {entry['type']!r}")
+        out["role"] = {"id": role}
+    return out
+
+
+def resolve_subject(term, scheme):
+    """Find the vocabulary entry Zenodo knows this term by.
+
+    ``.zenodo.json`` records a term and its vocabulary URI, which is what
+    the release-time ingestion reads.  The API instead wants Zenodo's own
+    identifier for the same entry, so look it up and insist on an exact
+    match rather than accepting the closest suggestion.
+    """
+    query = urllib.parse.urlencode({"q": f'"{term}"', "size": 50})
+    hits = request(f"/subjects?{query}")["hits"]["hits"]
+    for hit in hits:
+        if hit.get("subject") == term and hit.get("scheme") == scheme:
+            return hit["id"]
+    raise SyncError(
+        f"Zenodo has no {scheme} subject called {term!r}. Check it in "
+        f"{BASE}/subjects?q={urllib.parse.quote(term)}")
+
+
+def build_metadata(config):
+    """The metadata payload, from the contents of ``.zenodo.json``."""
+    subjects = [{"subject": keyword} for keyword in config["keywords"]]
+    for entry in config.get("subjects", []):
+        subjects.append({"id": resolve_subject(entry["term"],
+                                               entry["scheme"])})
+
+    metadata = {
+        "title": config["title"],
+        "description": f"<p>{config['description']}</p>",
+        "creators": [as_person(person, default_role="projectleader")
+                     for person in config["creators"]],
+        "contributors": [as_person(person)
+                         for person in config.get("contributors", [])],
+        "subjects": subjects,
+    }
+    return {key: value for key, value in metadata.items() if value}
+
+
+# ---------------------------------------------------------------------
+# Reading and writing the record
+# ---------------------------------------------------------------------
+
+def latest_record_id(concept=CONCEPT_RECORD):
+    """The newest version under the concept DOI."""
+    record = request(f"/records/{concept}")
+    versions = record.get("links", {}).get("latest")
+    if versions:
+        return str(request(versions)["id"])
+    return str(record["id"])
+
+
+def describe(metadata):
+    """A readable rendering of what would be sent."""
+    def named(person):
+        who = person["person_or_org"]
+        return f"{who['family_name']}, {who.get('given_name', '')}"
+
+    lines = [f"  title         {metadata['title']}"]
+    for person in metadata.get("creators", []):
+        lines.append(f"  creator       {named(person)}")
+    for person in metadata.get("contributors", []):
+        role = person.get("role", {}).get("id", "-")
+        lines.append(f"  contributor   {named(person)}  [{role}]")
+    free = [s["subject"] for s in metadata["subjects"] if "subject" in s]
+    linked = [s["id"] for s in metadata["subjects"] if "id" in s]
+    lines.append(f"  keywords      {len(free)}: {', '.join(free)}")
+    lines.append(f"  subjects      {len(linked)}: {', '.join(linked)}")
+    return "\n".join(lines)
+
+
+def sync(record_id, metadata, token):
+    """Edit, update and republish. The DOI is unchanged by this."""
+    print(f"  creating a draft of record {record_id}")
+    draft = request(f"/records/{record_id}/draft", method="POST", token=token)
+
+    merged = dict(draft["metadata"])
+    merged.update(metadata)
+    print("  writing the metadata")
+    request(f"/records/{record_id}/draft", method="PUT",
+            payload={"metadata": merged}, token=token)
+
+    print("  publishing")
+    published = request(f"/records/{record_id}/draft/actions/publish",
+                        method="POST", token=token)
+    return published
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--write", action="store_true",
+                        help="apply the changes (needs ZENODO_TOKEN)")
+    parser.add_argument("--record", metavar="ID",
+                        help="record to update (default: newest version)")
+    parser.add_argument("--config", type=pathlib.Path,
+                        default=pathlib.Path(__file__).parent.parent
+                        / ".zenodo.json")
+    args = parser.parse_args(argv)
+
+    config = json.loads(args.config.read_text())
+    metadata = build_metadata(config)
+    record_id = args.record or latest_record_id()
+
+    print(f"record https://zenodo.org/records/{record_id}")
+    print(describe(metadata))
+
+    if not args.write:
+        print("\ndry run; pass --write to apply")
+        return 0
+
+    token = os.environ.get("ZENODO_TOKEN")
+    if not token:
+        raise SyncError(
+            "ZENODO_TOKEN is not set. Create a token with the "
+            "deposit:write and deposit:actions scopes at "
+            "https://zenodo.org/account/settings/applications/tokens/new/")
+
+    published = sync(record_id, metadata, token)
+    print(f"\ndone: {published['links']['self_html']}")
+    print(f"DOI {published['doi']} (unchanged)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SyncError as error:
+        print(f"error: {error}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
> *"can't you do it using a Zenodo API or the like?"*

Yes. `RELEASING.md` had a step that read: after each release, open the record,
retype the MeSH, GEMET and EuroSciVoc terms into the interface, publish. That
is a step someone will skip, and it existed only because `.zenodo.json`'s
release-time ingestion may or may not honour the `subjects` block — something
we do not control.

The API has no such ambiguity.

## `tools/zenodo_sync.py`

Reads `.zenodo.json`, resolves each controlled term to the identifier Zenodo
knows it by, then edits, updates and republishes the record. **The DOI does not
change.** Standard library only; no token needed to see what it would send.

```console
$ python tools/zenodo_sync.py
record https://zenodo.org/records/22151794
  title         music: extreme-fidelity synthesis of musical elements
  creator       Fabbri, Renato
  contributor   Donati, Jacopo  [other]
  keywords      19: audio, music, synthesis, sound synthesis, additive synthesis,
                psychoacoustics, psychophysics, signal processing, sonification,
                data sonification, binaural, spatialization, change ringing,
                campanology, algorithmic composition, computer music, Python,
                numpy, MASS framework
  subjects      10: mesh:D009146, mesh:D009146Q000523, gemet:concept/5449,
                mesh:D011571, mesh:D011601, mesh:D000162, mesh:D013017,
                mesh:D012815, euroscivoc:1215, euroscivoc:273

dry run; pass --write to apply
```

That output is from the live API — every one of the ten controlled terms
resolved.

### Design notes

- **Exact matches only.** `resolve_subject` requires the term *and* the
  vocabulary to match, and raises naming the search URL otherwise. Zenodo's
  suggestion endpoint is fuzzy; a release script quietly tagging the record
  with `Image Processing, Computer-Assisted` because it ranked higher is
  exactly the failure worth refusing.
- **It closes the name trap.** Zenodo's interface takes the family name
  *first*, which is not evident from looking at it — that is how Jacopo Donati
  ended up recorded with his given name as his surname. `split_name` does it
  from the file, so there is one place it can go wrong instead of one per
  release.
- **macOS CA bundle.** A python.org Python ships without one wired in and
  fails every HTTPS call with `CERTIFICATE_VERIFY_FAILED` until its *Install
  Certificates* command is run. The script prefers `certifi`, which is
  installed alongside it either way. I hit this writing it.
- **No test file.** `tools/` sits outside the package, `--cov=music` does not
  see it, and importing it from `tests/` would mean putting back a `sys.path`
  hack that was deliberately removed earlier. The dry run is the check, and
  `RELEASING.md` says to run it.

## Also

- **ORCID `0000-0002-9699-629X`** recorded in both `.zenodo.json` and
  `CITATION.cff`. It was already on the Zenodo record and in neither file here.
- `ruff` now covers `tools/`, in CI and in the README.
- `RELEASING.md`'s verification step keeps the one genuinely
  counter-intuitive fact: check the **DataCite export**, not
  `/api/records/<id>`, which omits `subjects` entirely and made the 1.1.0
  record look unkeyworded when it was fully tagged. That misread cost a round
  trip.

This folds into 1.1.1, which is merged but not yet tagged or uploaded, so the
artifacts have been rebuilt.

## Gate

`ruff` clean over `music tests examples tools conftest.py` · **481 tests, 100%
coverage** · `cffconvert --validate` passes · `twine check` passes on both
artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
