### PR TITLE
Share the CA handling between the two release scripts

### DIFF
--- a/tools/release.py
+++ b/tools/release.py
@@ -32,6 +32,10 @@ import sys
 import urllib.error
 import urllib.request
 
+# Running this as a script puts tools/ first on sys.path, so its sibling
+# is importable by name. The CA handling belongs in one place.
+from zenodo_sync import ssl_context
+
 ROOT = pathlib.Path(__file__).parent.parent
 
 
@@ -101,7 +105,8 @@ def check_not_on_pypi(version):
     """PyPI never releases a version number back, so ask first."""
     url = f"https://pypi.org/pypi/music/{version}/json"
     try:
-        urllib.request.urlopen(url, timeout=30).read()
+        urllib.request.urlopen(url, timeout=30,
+                               context=ssl_context()).read()
     except urllib.error.HTTPError as error:
         if error.code == 404:
             step(f"PyPI does not have {version} yet")


### PR DESCRIPTION
Found by running `tools/release.py` for the first time: it failed at the PyPI check with `CERTIFICATE_VERIFY_FAILED`, because a python.org Python on macOS ships without a CA bundle wired in.

`zenodo_sync.py` already prefers `certifi` for exactly this reason, so import that rather than write it twice. Running the script as a script puts `tools/` first on `sys.path`, so the sibling import needs no path manipulation.

The rest of the script behaved: run from a branch, it correctly refused with `on branch fix/release-ssl, not master`.