### PR TITLE
Record what the 1.1.1 deposit settled about .zenodo.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [Unreleased]
+### Changed
+- `RELEASING.md` records what the 1.1.1 deposit settled: Zenodo's GitHub
+  ingestion reads `.zenodo.json` for the title, the creators, the contributors,
+  the description and the free-text keywords, and **ignores the `subjects`
+  block**. All nineteen keywords came across; all ten controlled-vocabulary
+  terms did not. Running `tools/zenodo_sync.py --write` after a release is
+  therefore required rather than precautionary.
+
 ## [1.1.1] - 2026-08-29
 Documentation and metadata only; no change to any rendered sound. It exists
 because the page PyPI shows can only be refreshed by an upload, and the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,12 +28,16 @@ logged in.
 ## After: sync the Zenodo record
 
 Zenodo builds each new deposit from `.zenodo.json` when the release is
-published, but do not rely on that alone: whether its ingestion honours the
-`subjects` block -- the controlled-vocabulary terms, as opposed to the
-free-text keywords -- is not something we control, and a record corrected by
-hand drifts from the file the moment anyone edits it.
+published, and gets most of it right: at 1.1.1 the title, the author, Jacopo
+Donati as a contributor, the description and all nineteen free-text keywords
+came across untouched.
 
-Push the file onto the record instead:
+**It ignores the `subjects` block entirely.** The controlled-vocabulary terms
+-- the MeSH, GEMET and EuroSciVoc entries -- arrived as zero linked subjects,
+measured on the 1.1.1 deposit. This is not a maybe; the release step below is
+required, not a precaution.
+
+So push the file onto the record after every release:
 
 ```console
 python tools/zenodo_sync.py            # show what it would send


### PR DESCRIPTION
The open question from #79 and #80 was whether Zenodo's GitHub ingestion honours the `subjects` block. **It does not.**

Measured on the [1.1.1 deposit](https://zenodo.org/records/22152018):

| | |
|---|---|
| title, creators, contributors, description | came across correctly |
| free-text `keywords` | **19 of 19** |
| controlled-vocabulary `subjects` | **0 of 10** |

So `RELEASING.md` no longer hedges: `tools/zenodo_sync.py --write` after a release is required, not a precaution. Which is what the script was written for.