### PR TITLE
Read the Zenodo draft in the shape the write API expects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 ## [Unreleased]
+### Fixed
+- `tools/zenodo_sync.py` read the draft it was updating in Zenodo's legacy
+  serialization and wrote it back to an API that speaks the other one, where a
+  resource type is `{"id": ...}` rather than `{"title": ..., "type": ...}` and
+  a relation is an object rather than a string. Writing the wrong shape back
+  stripped exactly those fields, and the publish then failed validation on
+  them. It now re-reads the draft as `application/vnd.inveniordm.v1+json`.
+- A failed publish left a half-written draft on the record. The draft is now
+  discarded on failure, so the published record is what it was.
+
 ### Changed
 - `RELEASING.md` records what the 1.1.1 deposit settled: Zenodo's GitHub
   ingestion reads `.zenodo.json` for the title, the creators, the contributors,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,6 +32,9 @@ published, and gets most of it right: at 1.1.1 the title, the author, Jacopo
 Donati as a contributor, the description and all nineteen free-text keywords
 came across untouched.
 
+It also honours `related_identifiers`, which arrived complete with their
+relation types.
+
 **It ignores the `subjects` block entirely.** The controlled-vocabulary terms
 -- the MeSH, GEMET and EuroSciVoc entries -- arrived as zero linked subjects,
 measured on the 1.1.1 deposit. This is not a maybe; the release step below is

--- a/tools/zenodo_sync.py
+++ b/tools/zenodo_sync.py
@@ -76,11 +76,20 @@ def ssl_context():
     return ssl.create_default_context(cafile=certifi.where())
 
 
-def request(path, *, method="GET", payload=None, token=None):
+#: Zenodo serves records in two shapes. The default is its legacy one,
+#: where a resource type is ``{"title": ..., "type": ...}`` and a relation
+#: is a bare string; the write API speaks the other, where both are
+#: ``{"id": ...}``. Reading in the wrong one and writing it back strips
+#: exactly those fields, and the publish then fails validation on them.
+RDM = "application/vnd.inveniordm.v1+json"
+
+
+def request(path, *, method="GET", payload=None, token=None,
+            accept="application/json"):
     """Call the Zenodo API and return the decoded body, or None."""
     url = path if path.startswith("http") else f"{BASE}{path}"
     data = None
-    headers = {"Accept": "application/json"}
+    headers = {"Accept": accept}
     if payload is not None:
         data = json.dumps(payload).encode()
         headers["Content-Type"] = "application/json"
@@ -220,20 +229,32 @@ def describe(metadata):
 
 
 def sync(record_id, metadata, token):
-    """Edit, update and republish. The DOI is unchanged by this."""
+    """Edit, update and republish. The DOI is unchanged by this.
+
+    A draft carries everything the published record has, and a PUT
+    replaces the metadata wholesale, so what is not being changed has to
+    be read back and sent again -- in the same shape the write API
+    expects, which is why the draft is re-read as ``RDM``.
+    """
     print(f"  creating a draft of record {record_id}")
-    draft = request(f"/records/{record_id}/draft", method="POST", token=token)
+    request(f"/records/{record_id}/draft", method="POST", token=token)
+    draft = request(f"/records/{record_id}/draft", token=token, accept=RDM)
 
     merged = dict(draft["metadata"])
     merged.update(metadata)
     print("  writing the metadata")
     request(f"/records/{record_id}/draft", method="PUT",
-            payload={"metadata": merged}, token=token)
+            payload={"metadata": merged}, token=token, accept=RDM)
 
     print("  publishing")
     published = request(f"/records/{record_id}/draft/actions/publish",
                         method="POST", token=token)
     return published
+
+
+def discard(record_id, token):
+    """Throw away a draft, leaving the published record as it was."""
+    request(f"/records/{record_id}/draft", method="DELETE", token=token)
 
 
 def main(argv=None):
@@ -268,7 +289,12 @@ def main(argv=None):
             "deposit:write and deposit:actions scopes at "
             "https://zenodo.org/account/settings/applications/tokens/new/")
 
-    published = sync(record_id, metadata, token)
+    try:
+        published = sync(record_id, metadata, token)
+    except SyncError:
+        print("  discarding the draft; the published record is untouched")
+        discard(record_id, token)
+        raise
     print(f"\ndone: {published['links']['self_html']}")
     print(f"DOI {published['doi']} (unchanged)")
     return 0


### PR DESCRIPTION
Read the Zenodo draft in the shape the write API expects

The first --write failed at publish: metadata.resource_type missing,
and a missing relation_type on each of the three related identifiers.

Zenodo serves records in two serializations. The default is its legacy
one, where a resource type is {"title": ..., "type": ...} and a relation
is a bare string. The write API speaks the other, where both are
{"id": ...}. A PUT replaces the metadata wholesale, so the parts not
being changed have to be read back and sent again -- and reading them in
the legacy shape stripped precisely the fields the publish then failed
on.

So the draft is re-read as application/vnd.inveniordm.v1+json before the
merge. A failed publish also discards its draft now, rather than leaving
a half-written one on the record.

Verified against the 1.1.1 deposit: ten linked subjects where there were
none, nineteen free-text keywords, the title, the creator, the
contributor, the description and all four related identifiers unchanged.
DOI 10.5281/zenodo.22152018, as before.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
