### PR TITLE
Fill in the Zenodo metadata the deposit was leaving empty

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -3,11 +3,35 @@
   "upload_type": "software",
   "license": "MIT",
   "access_right": "open",
+  "language": "eng",
   "creators": [
     {
       "name": "Fabbri, Renato",
       "affiliation": "BioSynCare.com, IFSC-USP, Juntadados, Nós Digitais, CDTL, ICMC/USP",
-      "orcid": "0000-0002-9699-629X"
+      "orcid": "0000-0002-9699-629X",
+      "affiliations": [
+        {
+          "id": "02f1crb75"
+        },
+        {
+          "id": "036rp1748"
+        },
+        {
+          "name": "ICMC/USP"
+        },
+        {
+          "name": "BioSynCare.com"
+        },
+        {
+          "name": "Juntadados"
+        },
+        {
+          "name": "Nós Digitais"
+        },
+        {
+          "name": "CDTL"
+        }
+      ]
     }
   ],
   "contributors": [
@@ -90,6 +114,16 @@
       "identifier": "http://data.europa.eu/8mn/euroscivoc/273"
     }
   ],
+  "dates": [
+    {
+      "date": "2016-02-20",
+      "type": "created",
+      "description": "First commit in the repository."
+    }
+  ],
+  "references": [
+    "Fabbri, R., Vieira da Silva Junior, V., Pessotti, A. C. S., Corrêa, D. C., & Oliveira Jr., O. N. (2017). Musical elements in the discrete-time representation of sound. arXiv:1412.6853. https://arxiv.org/abs/1412.6853"
+  ],
   "related_identifiers": [
     {
       "identifier": "arXiv:1412.6853",
@@ -109,5 +143,16 @@
       "resource_type": "publication-softwaredocumentation",
       "scheme": "url"
     }
-  ]
+  ],
+  "custom_fields": {
+    "code:codeRepository": "https://github.com/ttm/music",
+    "code:programmingLanguage": [
+      {
+        "id": "python"
+      }
+    ],
+    "code:developmentStatus": {
+      "id": "active"
+    }
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
 ### Added
+- Five fields of Zenodo metadata the deposit had been leaving empty, all
+  carried in `.zenodo.json` so they survive every release:
+  - **The software block.** `code:codeRepository`, `code:programmingLanguage`
+    and `code:developmentStatus` were entirely absent, so nothing told a
+    machine reading the record that this is Python.
+  - **ROR-identified affiliations.** The author's affiliation was one string
+    naming six institutions, which resolves to nothing. Two of them are in
+    ROR -- Instituto de Física de São Carlos (`02f1crb75`) and Universidade de
+    São Paulo (`036rp1748`) -- and are now linked; the rest stay as names,
+    since they have no ROR entry.
+  - **A `created` date of 2016-02-20**, the repository's first commit. The
+    record's publication date is the release date, which made a decade of work
+    look like a day of it.
+  - **The MASS article as a reference**, distinct from the related identifier:
+    one says the software derives from the article, the other cites it.
+  - **The language**, `eng`.
+
 - `tools/zenodo_sync.py` attaches the changelog entry for the record's version
   to the Zenodo deposit as an additional description of type `technical-info`,
   so a version record says what changed in that version and not only what the

--- a/tools/zenodo_sync.py
+++ b/tools/zenodo_sync.py
@@ -139,7 +139,13 @@ def as_person(entry, *, default_role=None):
                                   "identifier": entry["orcid"]}]
 
     out = {"person_or_org": person}
-    if entry.get("affiliation"):
+    # A list lets an affiliation carry its ROR identifier, which resolves
+    # to a real organisation, alongside ones that have no ROR entry and
+    # can only be named. The single string is the fallback, and is what
+    # the release-time ingestion reads.
+    if entry.get("affiliations"):
+        out["affiliations"] = entry["affiliations"]
+    elif entry.get("affiliation"):
         out["affiliations"] = [{"name": entry["affiliation"]}]
 
     role = (entry.get("type") or default_role or "").lower()
@@ -295,6 +301,20 @@ def build_metadata(config, *, with_description=False, release_notes=None):
             "description": markdown_to_html(release_notes),
             "type": {"id": "technical-info"},
         }]
+
+    if config.get("language"):
+        metadata["languages"] = [{"id": config["language"]}]
+    if config.get("references"):
+        metadata["references"] = [{"reference": reference}
+                                  for reference in config["references"]]
+    if config.get("dates"):
+        metadata["dates"] = [
+            {"date": entry["date"],
+             "type": {"id": entry["type"]},
+             **({"description": entry["description"]}
+                if entry.get("description") else {})}
+            for entry in config["dates"]]
+
     return {key: value for key, value in metadata.items() if value}
 
 
@@ -317,7 +337,7 @@ def record_version(record_id):
     return record.get("metadata", {}).get("version") or ""
 
 
-def describe(metadata):
+def describe(metadata, custom_fields=None):
     """A readable rendering of what would be sent."""
     def named(person):
         who = person["person_or_org"]
@@ -342,10 +362,15 @@ def describe(metadata):
                  + (f"attached, {len(extra[0]['description'])} characters "
                     f"of HTML from the changelog"
                     if extra else "none found in the changelog"))
+    for key in ("languages", "dates", "references"):
+        if metadata.get(key):
+            lines.append(f"  {key:<13} {len(metadata[key])}")
+    if custom_fields:
+        lines.append(f"  custom fields {', '.join(sorted(custom_fields))}")
     return "\n".join(lines)
 
 
-def sync(record_id, metadata, token):
+def sync(record_id, metadata, token, custom_fields=None):
     """Edit, update and republish. The DOI is unchanged by this.
 
     A draft carries everything the published record has, and a PUT
@@ -359,9 +384,16 @@ def sync(record_id, metadata, token):
 
     merged = dict(draft["metadata"])
     merged.update(metadata)
+
+    # custom_fields are a sibling of metadata in the payload, not a key
+    # inside it, and the software block lives there.
+    fields = dict(draft.get("custom_fields") or {})
+    fields.update(custom_fields or {})
+
     print("  writing the metadata")
     request(f"/records/{record_id}/draft", method="PUT",
-            payload={"metadata": merged}, token=token, accept=RDM)
+            payload={"metadata": merged, "custom_fields": fields},
+            token=token, accept=RDM)
 
     print("  publishing")
     published = request(f"/records/{record_id}/draft/actions/publish",
@@ -403,7 +435,7 @@ def main(argv=None):
                               release_notes=notes)
 
     print(f"record https://zenodo.org/records/{record_id}")
-    print(describe(metadata))
+    print(describe(metadata, config.get("custom_fields")))
 
     if not args.write:
         print("\ndry run; pass --write to apply")
@@ -417,7 +449,8 @@ def main(argv=None):
             "https://zenodo.org/account/settings/applications/tokens/new/")
 
     try:
-        published = sync(record_id, metadata, token)
+        published = sync(record_id, metadata, token,
+                         config.get("custom_fields"))
     except SyncError:
         print("  discarding the draft; the published record is untouched")
         discard(record_id, token)


### PR DESCRIPTION
Fill in the Zenodo metadata the deposit was leaving empty

An audit of the record against what the API accepts found nine unused
metadata fields and an empty custom_fields block. Five are worth filling
and are now carried in .zenodo.json, so they survive every release
rather than being a one-off edit:

The software block -- code:codeRepository, code:programmingLanguage and
code:developmentStatus -- was entirely absent, so nothing told a machine
reading the record that this is Python at all.

Affiliations were a single string naming six institutions, which
resolves to nothing. Two are in ROR, Instituto de Física de São Carlos
and Universidade de São Paulo, and are linked by identifier; the other
four have no ROR entry and stay as names. Searching ROR for ICMC and
Juntadados returns unrelated institutions, so neither was guessed at.

A created date of 2016-02-20, the repository's first commit. The record
carried only the release date, which made a decade of work look like a
day of it.

The MASS article as a reference, which is a different claim from the
related identifier already there: one says the software derives from the
article, the other cites it.

The language, eng.

Deliberately not added: funding, which nobody has told me about and
which would be a fabrication on a citable record; and a Software
Heritage identifier, since the archive's latest snapshot predates this
release and Zenodo deposits its own.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
