### PR TITLE
Stop the README claiming structures it does not have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
   the next ones outside the span and emit tags that cross.
 
 ### Fixed
+- The README said `structures` held "scales, chords, counterpoint, tunings".
+  It holds permutations, peals and symmetry; none of those four exist. The
+  sentence now describes what is there and links the issue for what is not.
 - `tools/zenodo_sync.py` read the draft it was updating in Zenodo's legacy
   serialization and wrote it back to an API that speaks the other one, where a
   resource type is `{"id": ...}` rather than `{"title": ..., "type": ...}` and

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The modules are:
   * **filters** for the application of filters such as ADSR envelopes, fades, IIR and FIR, reverb, loudness, and localization.
   * **io** for reading, writing and playing audio, both mono and stereo.
   * **functions** for normalization.
-* **structures** for higher level musical structures such as permutations (and related to algebraic groups and change ringing peals), scales, chords, counterpoint, tunings, etc.
+* **structures** for higher level musical structures: permutations and the algebraic groups they form, change-ringing peals, and symmetry. Scales, chords, counterpoint and tunings are [not there yet](https://github.com/ttm/music/issues/1).
 * **legacy** for musical pieces that are rendered with the Music package and might be used as material to make more music.
 * **tables** for the generation of lookup tables for some basic waveform.
 * **utils** for various functions regarding conversions, mix, etc.


### PR DESCRIPTION
The README listed *"scales, chords, counterpoint, tunings"* among what `music.structures` holds. It holds permutations, peals and symmetry — none of those four exist anywhere in the package.

```
>>> [n for n in dir(music.structures) if not n.startswith('_')]
['GenericPeal', 'InterestingPermutations', 'Peals', 'PlainChanges', 'dist',
 'peals', 'permutations', 'print_peal', 'symmetry', 'transpose_permutation']
```

Found while triaging the 2016 issues — #1 and #4 ask for exactly those missing pieces, and had nowhere to live.