### PR TITLE
Stop translate_to_abc silently dropping notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 ### Fixed
+- **`translate_to_abc()` silently dropped notes.** It zipped pitches against
+  durations, so the tail of whichever was longer vanished: five notes with
+  three durations produced a three-note score, with no error. `write_abc()`
+  appends the lyric line separately, so the words then pointed at notes that
+  were no longer there. It raises now, naming both counts.
+- `Notes.make_dict()` built 96 note names and zipped them against 85 MIDI
+  numbers, leaving eleven quietly unused. The slice is explicit now, so the
+  range the dictionary covers is a decision rather than an accident of `zip`.
 - **`iir()` was quadratic in the length of the signal.** It rebuilt a reversed
   copy of everything filtered so far on every sample, then threw all but the
   first `len(a)` of it away. One second of audio at 44.1 kHz took about three

--- a/music/singing/perform.py
+++ b/music/singing/perform.py
@@ -77,10 +77,45 @@ def write_abc(text, notes, durs, M='4/4', L='1/4', Q=120, K='C', reference=60):
 
 
 def translate_to_abc(notes, durs, reference):
+    """Render pitches and durations as an ABC notation fragment.
+
+    Parameters
+    ----------
+    notes : sequence of int
+        Semitone offsets from ``reference``.
+    durs : sequence
+        One duration per note.
+    reference : int
+        The MIDI note that offset zero refers to.
+
+    Returns
+    -------
+    str
+        The notes with their durations, ready to append to an ABC header.
+
+    Raises
+    ------
+    ValueError
+        If there is not exactly one duration per note. Zipping them
+        silently discarded the tail of whichever was longer, so five
+        notes with three durations produced a three-note score -- and
+        ``write_abc`` appends the lyric line separately, which then
+        pointed at notes that were no longer there.
+
+    Examples
+    --------
+    >>> translate_to_abc([0, 2, 4], [1, 1, 1], reference=60)
+    '=c=de'
+
+    """
+    if len(notes) != len(durs):
+        raise ValueError(
+            f"got {len(notes)} notes and {len(durs)} durations; "
+            f"there must be exactly one duration per note")
     durs = [str(i).replace('-', '/') for i in durs]
     durs = [i if i != '1' else '' for i in durs]
     notes = converter.convert(notes, reference)
-    return ''.join([i + j for i, j in zip(notes, durs)])
+    return ''.join([i + j for i, j in zip(notes, durs, strict=True)])
 
 
 class Notes:
@@ -100,8 +135,12 @@ class Notes:
         notes___u = [note + "'" for note in notes__u]
         notes_all = notes____ + notes___ + notes__ + notes_ + notes + \
             notes_u + notes__u + notes___u
-        self.notes_dict = dict([(i, j) for i, j in zip(range(12, 97),
-                                                       notes_all)])
+        # notes_all spans eight octaves, 96 names. The dictionary covers
+        # MIDI 12 to 96, which is 85 of them; the remaining eleven are
+        # deliberately unused. Sliced explicitly so that is a decision
+        # rather than something zip does quietly.
+        self.notes_dict = dict(zip(range(12, 97), notes_all[:85],
+                                   strict=True))
 
     def convert(self, notes, reference):
         if self.notes_dict is None:

--- a/tests/test_abc_notation.py
+++ b/tests/test_abc_notation.py
@@ -145,3 +145,30 @@ def test_sing_rejects_a_render_at_the_wrong_sample_rate(cache, monkeypatch):
 
     with pytest.raises(RuntimeError, match="44100"):
         perform.sing()
+
+
+def test_translate_to_abc_rejects_a_length_mismatch():
+    """Regression: notes and durations were zipped, so the tail of
+    whichever was longer vanished. Five notes with three durations
+    produced a three-note score, and since write_abc appends the lyric
+    line separately, the words then pointed at notes that were gone."""
+    from music.singing.perform import translate_to_abc
+
+    assert translate_to_abc([0, 2, 4], [1, 1, 1], reference=60) == "=c=de"
+
+    with pytest.raises(ValueError, match="5 notes and 3 durations"):
+        translate_to_abc([0, 2, 4, 5, 7], [1, 1, 1], reference=60)
+
+    with pytest.raises(ValueError, match="2 notes and 5 durations"):
+        translate_to_abc([0, 2], [1, 1, 1, 1, 1], reference=60)
+
+
+def test_the_note_dictionary_covers_the_midi_range_it_claims():
+    """The eight octaves of names are longer than the MIDI range the
+    dictionary maps, and the surplus is sliced off deliberately."""
+    from music.singing.perform import Notes
+
+    notes = Notes()
+    assert len(notes.notes_dict) == 85
+    assert min(notes.notes_dict) == 12
+    assert max(notes.notes_dict) == 96


### PR DESCRIPTION
Stop translate_to_abc silently dropping notes

It zipped pitches against durations, so the tail of whichever was longer
vanished without a word: five notes and three durations produced a
three-note score. write_abc appends the lyric line separately, so the
words then pointed at notes that were no longer in the score -- a wrong
result rather than a missing one.

It raises now, naming both counts.

Nearby, Notes.make_dict built 96 note names and zipped them against 85
MIDI numbers, leaving eleven unused. That truncation is correct -- the
dictionary covers MIDI 12 to 96 -- so it is an explicit slice now rather
than something zip does quietly, with strict=True to keep the two sides
honest.

Found by auditing the four zip-without-strict sites #68 reports. The
other two, in Being.render and IteratorSynth, pair sequences that are
equal by construction and are fine.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
