### PR TITLE
Fix what a review of everything since 1.1.1 turned up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 ## [Unreleased]
+### Note for anyone upgrading
+**matplotlib is no longer installed with the package.** If your code calls
+`PrimaryTables.draw_tables()`, or relied on `import music` having pulled
+matplotlib in for you, install `music[plot]` instead of `music`. Nothing else
+in the package uses it. Everything that synthesises, filters or writes audio
+is unaffected.
+
+`iir()` returns exactly the values it did before, bit for bit; it is only
+faster.
+
 ### Fixed
 - **`translate_to_abc()` silently dropped notes.** It zipped pitches against
   durations, so the tail of whichever was longer vanished: five notes with
   three durations produced a three-note score, with no error. `write_abc()`
   appends the lyric line separately, so the words then pointed at notes that
   were no longer there. It raises now, naming both counts.
+- A doctest in `PrimaryTables`'s class docstring called `draw_tables()` without
+  a skip marker, so enabling `--doctest-modules` hung the suite on a plot
+  window rather than failing it. All three examples in that module are marked
+  now.
+- `tools/zenodo_sync.py` could not find the changelog entry for the *oldest*
+  release: its lookahead required a following heading, so the last section in
+  the file never matched and its notes silently failed to attach.
 - `Notes.make_dict()` built 96 note names and zipped them against 85 MIDI
   numbers, leaving eleven quietly unused. The slice is explicit now, so the
   range the dictionary covers is a decision rather than an accident of `zip`.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,19 @@ gives you both, formatted.
 pip install music
 ```
 
-Requires Python 3.10 or newer. Every dependency comes with it; they are
-declared in
+Requires Python 3.10 or newer. Everything needed to synthesise, filter and
+write audio comes with it; the dependencies are declared in
 [pyproject.toml](https://github.com/ttm/music/blob/master/pyproject.toml).
+
+One thing is optional. `PrimaryTables.draw_tables()`, which plots the waveform
+tables so you can look at them, needs matplotlib:
+
+```console
+pip install 'music[plot]'
+```
+
+Nothing else in the package uses it, and leaving it out makes `import music`
+about 40% faster.
 
 To hack on it, install from a checkout so your edits take effect immediately:
 
@@ -188,7 +198,7 @@ pip install -e '.[dev,docs]'
 ```
 
 ```console
-pytest                                       # 481 tests, 100% coverage
+pytest                                       # 486 tests, 100% coverage
 mypy music                                   # type check
 ruff check music tests examples tools conftest.py  # lint, at PEP 8's 79 columns
 sphinx-build -b html -W docs docs/_build/html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,16 @@ Or from a checkout, which is convenient for hacking and debugging:
 
 Requires Python 3.10 or newer.
 
+:meth:`PrimaryTables.draw_tables <music.PrimaryTables.draw_tables>` plots the
+waveform tables and is the one thing that needs matplotlib, which is an extra:
+
+.. code-block:: console
+
+   pip install 'music[plot]'
+
+Nothing else in the package uses it, and leaving it out makes ``import music``
+about 40% faster.
+
 Where things live
 -----------------
 

--- a/music/tables.py
+++ b/music/tables.py
@@ -48,7 +48,9 @@ class PrimaryTables:
     Examples
     --------
     >>> primary_tables = PrimaryTables()
-    >>> primary_tables.draw_tables()  # Draw the waveform tables
+    >>> primary_tables.size
+    2048
+    >>> primary_tables.draw_tables()  # doctest: +SKIP
     """
     def __init__(self, size=2048):
         """Initialize the PrimaryTables class.
@@ -85,9 +87,13 @@ class PrimaryTables:
         -----
         matplotlib is imported here rather than at the top of the module.
         It is the only thing in the package that needs it, and importing
-        it eagerly cost about half of ``import music``'s total time and
-        pulled eight further packages into every installation, for a
-        function that only exists to look at the tables.
+        it eagerly cost about 40% of ``import music``'s total time --
+        1237 ms against 743 ms -- and pulled eight further packages into
+        every installation, for a function that only exists to look at
+        the tables.
+
+        The examples are marked ``+SKIP``: ``show()`` blocks on a window,
+        so a doctest run would hang rather than fail.
 
         Raises
         ------

--- a/tools/zenodo_sync.py
+++ b/tools/zenodo_sync.py
@@ -186,8 +186,11 @@ def changelog_section(version, path=None):
     """
     path = path or pathlib.Path(__file__).parent.parent / "CHANGELOG.md"
     version = version.lstrip("v")
+    # The lookahead has to accept end-of-file as well as the next
+    # heading, or the oldest release in the file never matches and its
+    # notes silently fail to attach.
     match = re.search(
-        rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[)",
+        rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)",
         path.read_text(), re.MULTILINE | re.DOTALL)
     return match.group(1).strip() if match else None
 


### PR DESCRIPTION
Fix what a review of everything since 1.1.1 turned up

Reviewing the diff rather than my own summaries of it found four things.

A doctest in PrimaryTables' class docstring still called draw_tables()
without a skip marker. Making matplotlib lazy covered the module
docstring and the method docstring and missed this one, so enabling
--doctest-modules hung the suite on a plot window instead of failing it.
All three are marked now, and the docstring says why.

The [plot] extra was documented nowhere a user would look. Someone
upgrading from 1.1.1 whose code calls draw_tables() would have met an
ImportError with nothing in the README or the docs to explain it. Both
now describe it, and the changelog has an upgrade note.

zenodo_sync could not find the changelog entry for the oldest release:
the lookahead required a following heading, so the last section in the
file never matched and its notes silently failed to attach.

The draw_tables docstring claimed matplotlib cost "about half" of import
music. Measured, it is 40% -- 1237 ms against 743 ms. The changelog said
40% and the docstring did not.

Also refreshes the README's test count, 481 to 486.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
