### PR TITLE
Point CITATION.cff at the archive it claims to describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ faster.
   three durations produced a three-note score, with no error. `write_abc()`
   appends the lyric line separately, so the words then pointed at notes that
   were no longer there. It raises now, naming both counts.
+- `CITATION.cff` named version 1.1.1 while its version DOI still pointed at
+  the 1.1.0 archive. The DOI can only be known after a release, so keeping it
+  current is now a documented release step rather than something anyone
+  remembers.
 - A doctest in `PrimaryTables`'s class docstring called `draw_tables()` without
   a skip marker, so enabling `--doctest-modules` hung the suite on a plot
   window rather than failing it. All three examples in that module are marked

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,10 @@ identifiers:
     description: >-
       Concept DOI, resolving to the most recent release of the software.
   - type: doi
-    value: 10.5281/zenodo.22151794
-    description: Archived snapshot of version 1.1.0.
+    value: 10.5281/zenodo.22152018
+    description: >-
+      Archived snapshot of the version this file names. Update it with
+      the version, after Zenodo has minted the DOI for the new release.
 url: https://ttm.github.io/music/
 abstract: >-
   Extreme-fidelity synthesis of musical elements, based on the MASS

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,6 +60,11 @@ from `.zenodo.json`.
 from https://zenodo.org/account/settings/applications/tokens/new/, in
 `ZENODO_TOKEN`. Reading needs none.
 
+Then update the version DOI in `CITATION.cff` to the one Zenodo has just
+minted, and commit it. The concept DOI never changes, but the version DOI
+names a specific archive, and it can only be known after the release — which
+is why it is a step here rather than something `tools/release.py` can check.
+
 Verify afterwards with the DataCite export rather than the record endpoint,
 which omits subjects entirely and will make a fully keyworded record look bare:
 


### PR DESCRIPTION
`CITATION.cff` said `version: 1.1.1` while its version DOI was still 1.1.0's (`22151794` rather than `22152018`). Anyone citing a specific version from that file got the wrong archive.

The concept DOI never changes, but a version DOI names a specific archive and can only be known **after** the release fires Zenodo — so `tools/release.py` cannot check it up front. It is a documented step in `RELEASING.md` now instead.

Still validates against CFF schema 1.2.0.