### PR TITLE
Make iir refuse what it cannot filter, and stop duplicating the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ faster.
   three durations produced a three-note score, with no error. `write_abc()`
   appends the lyric line separately, so the words then pointed at notes that
   were no longer there. It raises now, naming both counts.
+- **`iir()` returned two samples of nonsense for a stereo signal.** `len()` of
+  a two-dimensional array counts channels, so a `(2, n)` input produced a
+  two-element result rather than a filtered one -- silently. It raises now,
+  as it also does for an empty `b` (which raised `IndexError` from the
+  divisor) and for `b[0] == 0` (which produced an array of infinities behind a
+  `RuntimeWarning`).
+- `tools/release.py` carried a second copy of the changelog parser, with the
+  same end-of-file bug fixed above in `zenodo_sync`. It imports the one
+  implementation now, so the notes on a GitHub release and on a Zenodo deposit
+  cannot disagree.
+- `markdown_to_html` emitted a `<ul>` directly inside a `<ul>`, plus a stray
+  `</li>`, for a list whose first item was already indented.
 - `CITATION.cff` named version 1.1.1 while its version DOI still pointed at
   the 1.1.0 archive. The DOI can only be known after a release, so keeping it
   current is now a documented release step rather than something anyone

--- a/music/core/filters/impulse_response.py
+++ b/music/core/filters/impulse_response.py
@@ -85,6 +85,15 @@ def iir(sonic_vector, a, b):
     ndarray
         The filtered signal, the same length as the input.
 
+    Raises
+    ------
+    ValueError
+        If ``sonic_vector`` is not one-dimensional, or if ``b`` is empty
+        or begins with zero. A stereo array used to come back as a
+        two-element result -- ``len()`` of it counts channels, not
+        samples -- and a zero divisor produced an array of infinities
+        behind a warning. Filter one channel at a time.
+
     Notes
     -----
     The recurrence implemented is
@@ -125,6 +134,16 @@ def iir(sonic_vector, a, b):
     signal = np.asarray(sonic_vector, dtype=np.float64)
     a = np.asarray(a, dtype=np.float64)
     b = np.asarray(b, dtype=np.float64)
+
+    if signal.ndim != 1:
+        raise ValueError(
+            f"iir filters one channel at a time; got an array of shape "
+            f"{signal.shape}. Pass each channel separately.")
+    if b.size == 0:
+        raise ValueError("b must hold at least the divisor b[0]")
+    if b[0] == 0:
+        raise ValueError("b[0] is the divisor of the recurrence and "
+                         "cannot be zero")
 
     out = np.zeros(len(signal))
     for i in range(len(signal)):

--- a/tests/test_filters_response.py
+++ b/tests/test_filters_response.py
@@ -127,6 +127,23 @@ def test_iir_accepts_lists_as_documented():
     assert np.allclose(out, [1.0, 0.5, 0.25, 0.125])
 
 
+@pytest.mark.parametrize("signal, a, b, message", [
+    (np.ones((2, 4)), [1.], [1.], "one channel at a time"),
+    (np.ones(4), [1.], [], "at least the divisor"),
+    (np.ones(4), [1.], [0., .5], "cannot be zero"),
+])
+def test_iir_refuses_what_it_cannot_filter(signal, a, b, message):
+    """Each of these used to produce a wrong answer rather than an error.
+
+    A stereo array came back as two samples, because ``len()`` of a 2-D
+    array counts channels; an empty ``b`` raised IndexError from the
+    divisor; and a zero divisor produced an array of infinities behind a
+    RuntimeWarning.
+    """
+    with pytest.raises(ValueError, match=message):
+        music.iir(signal, a, b)
+
+
 def test_iir_matches_the_recurrence_it_documents():
     """Pin the semantics independently of the implementation.
 

--- a/tools/release.py
+++ b/tools/release.py
@@ -35,7 +35,7 @@ import urllib.request
 
 # Running this as a script puts tools/ first on sys.path, so its sibling
 # is importable by name. The CA handling belongs in one place.
-from zenodo_sync import ssl_context
+from zenodo_sync import changelog_section, ssl_context
 
 ROOT = pathlib.Path(__file__).parent.parent
 
@@ -155,14 +155,15 @@ def build():
 # ---------------------------------------------------------------------
 
 def release_notes(version):
-    """The changelog's section for this version, as the release body."""
-    changelog = (ROOT / "CHANGELOG.md").read_text()
-    match = re.search(
-        rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[)",
-        changelog, re.MULTILINE | re.DOTALL)
-    if not match:
+    """The changelog's section for this version, as the release body.
+
+    The extraction is zenodo_sync's, so the notes on the GitHub release
+    and the notes on the Zenodo deposit come from one implementation
+    rather than two that can disagree.
+    """
+    body = changelog_section(version)
+    if body is None:
         raise ReleaseError(f"no changelog section for {version}")
-    body = match.group(1).strip()
     return (
         f"```console\npip install -U music\n```\n\n"
         f"[Tutorial](https://ttm.github.io/music/tutorial.html) · "

--- a/tools/zenodo_sync.py
+++ b/tools/zenodo_sync.py
@@ -254,7 +254,10 @@ def markdown_to_html(markdown):
                        f"</h{level}>")
         elif bullet:
             flush()
-            want = 1 if len(bullet.group(1)) < 2 else 2
+            # A nested level has to hang off an item, so a list that
+            # opens already indented starts at depth one rather than
+            # emitting a <ul> straight inside a <ul>.
+            want = min(1 if len(bullet.group(1)) < 2 else 2, depth + 1)
             close_lists(want)
             while depth < want:
                 if depth and out[-1].endswith("</li>"):


### PR DESCRIPTION
Make iir refuse what it cannot filter, and stop duplicating the parser

A second review pass, probing edge cases rather than re-reading the
diff.

iir returned two samples of nonsense for a stereo signal. len() of a
two-dimensional array counts channels, not samples, so a (2, n) input
produced a two-element result with no error at all -- the same shape of
defect as the type(x) in (...) sites fixed in 1.1.0. It also raised
IndexError from the divisor for an empty b, and produced an array of
infinities behind a RuntimeWarning for b[0] == 0. All three raise
ValueError now, naming what is wrong. fir already rejected 2-D input, so
this is consistent as well as correct.

release.py carried its own copy of the changelog-section parser, with
the same end-of-file bug just fixed in zenodo_sync: the oldest release
in the file never matched. Rather than fix it twice, release.py imports
the one implementation, so the notes on a GitHub release and on a Zenodo
deposit cannot drift apart.

markdown_to_html emitted a <ul> directly inside a <ul>, and a stray
</li>, when a list's first item was already indented. Valid now at every
nesting depth tested.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
