### PR TITLE
Let fir name the argument it cannot use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ faster.
   as it also does for an empty `b` (which raised `IndexError` from the
   divisor) and for `b[0] == 0` (which produced an array of infinities behind a
   `RuntimeWarning`).
+- `fir()` rejected bad input with numpy's own messages -- "object too deep for
+  desired array" for a stereo array, "v cannot be empty" for an empty one --
+  which name neither the argument nor the problem. It now names both, matching
+  the guards `iir()` grew.
 - `tools/release.py` carried a second copy of the changelog parser, with the
   same end-of-file bug fixed above in `zenodo_sync`. It imports the one
   implementation now, so the notes on a GitHub release and on a Zenodo deposit

--- a/music/core/filters/impulse_response.py
+++ b/music/core/filters/impulse_response.py
@@ -32,6 +32,14 @@ def fir(samples, sonic_vector, freq=True, max_freq=True):
         The kernel is symmetric, so the filter is linear phase and the
         output is delayed by half the kernel.
 
+    Raises
+    ------
+    ValueError
+        If either argument is not one-dimensional, or if either is
+        empty. numpy raises for these anyway, but with messages such as
+        "object too deep for desired array", which name neither the
+        argument nor the problem.
+
     Notes
     -----
     If freq=True, the samples are the absolute values of the frequency
@@ -54,6 +62,16 @@ def fir(samples, sonic_vector, freq=True, max_freq=True):
     """
     samples = np.asarray(samples, dtype=np.float64)
     sonic_vector = np.asarray(sonic_vector, dtype=np.float64)
+
+    for name, array in (("samples", samples),
+                        ("sonic_vector", sonic_vector)):
+        if array.ndim != 1:
+            raise ValueError(
+                f"fir works on one-dimensional arrays; {name} has shape "
+                f"{array.shape}. Filter each channel separately.")
+        if array.size == 0:
+            raise ValueError(f"{name} is empty")
+
     if not freq:
         return np.convolve(samples, sonic_vector)
     if max_freq:

--- a/tests/test_filters_response.py
+++ b/tests/test_filters_response.py
@@ -127,6 +127,20 @@ def test_iir_accepts_lists_as_documented():
     assert np.allclose(out, [1.0, 0.5, 0.25, 0.125])
 
 
+@pytest.mark.parametrize("samples, signal, message", [
+    (np.ones(3), np.ones((2, 4)), "sonic_vector has shape"),
+    (np.ones((2, 3)), np.ones(4), "samples has shape"),
+    (np.array([]), np.ones(4), "samples is empty"),
+    (np.ones(3), np.array([]), "sonic_vector is empty"),
+])
+def test_fir_names_the_argument_it_cannot_use(samples, signal, message):
+    """numpy raised for all of these already, with messages like "object
+    too deep for desired array" that name neither the argument nor the
+    problem. Matches the guards iir grew."""
+    with pytest.raises(ValueError, match=message):
+        music.fir(samples, signal)
+
+
 @pytest.mark.parametrize("signal, a, b, message", [
     (np.ones((2, 4)), [1.], [1.], "one channel at a time"),
     (np.ones(4), [1.], [], "at least the divisor"),


### PR DESCRIPTION
Every bad input already raised, so unlike the `iir` case nothing was silently wrong — but with numpy's messages:

| input | before | after |
|---|---|---|
| stereo `sonic_vector` | `object too deep for desired array` | `fir works on one-dimensional arrays; sonic_vector has shape (2, 4). Filter each channel separately.` |
| empty `samples` | `Invalid number of FFT data points (0) specified` | `samples is empty` |
| empty `sonic_vector` | `v cannot be empty` | `sonic_vector is empty` |

Matches the guards `iir` grew in #96, so the two filters in this module behave the same way when handed something they cannot filter.