### PR TITLE
Fix the .zenodo.json field that failed the 1.2.0 archive

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -116,8 +116,8 @@
   ],
   "dates": [
     {
-      "date": "2016-02-20",
-      "type": "created",
+      "start": "2016-02-20",
+      "type": "Created",
       "description": "First commit in the repository."
     }
   ],

--- a/tests/test_zenodo_metadata.py
+++ b/tests/test_zenodo_metadata.py
@@ -1,0 +1,70 @@
+""".zenodo.json has to satisfy Zenodo's release-time validator.
+
+A malformed field there does not degrade the deposit, it *fails the
+archive*: 1.2.0's first two attempts died with "Extra metadata load
+failed" because ``dates`` used the REST API's shape -- ``date`` and a
+lowercase type -- in a file that Zenodo validates against its legacy
+schema, which wants ``start`` and a capitalised one.
+
+Nothing catches that until a release has already gone out, so these
+check statically what the validator would have said.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+ZENODO = pathlib.Path(__file__).parent.parent / ".zenodo.json"
+
+#: Keys Zenodo's legacy deposit metadata accepts, plus custom_fields,
+#: which the REST API reads and the ingestion tolerates.
+KNOWN_KEYS = {
+    "upload_type", "publication_type", "image_type", "publication_date",
+    "title", "creators", "description", "access_right", "license",
+    "embargo_date", "access_conditions", "doi", "prereserve_doi",
+    "keywords", "notes", "related_identifiers", "contributors",
+    "references", "communities", "grants", "subjects", "version",
+    "language", "locations", "dates", "method", "custom_fields",
+}
+
+#: The four the legacy schema documents for a date entry.
+DATE_TYPES = {"Collected", "Valid", "Withdrawn", "Created"}
+
+
+@pytest.fixture(scope="module")
+def metadata():
+    return json.loads(ZENODO.read_text())
+
+
+def test_every_key_is_one_zenodo_knows(metadata):
+    unknown = set(metadata) - KNOWN_KEYS
+    assert not unknown, f"Zenodo will not recognise {sorted(unknown)}"
+
+
+def test_dates_use_the_shape_the_ingestion_validates(metadata):
+    """Regression: `date` and a lowercase type failed the whole archive."""
+    for entry in metadata.get("dates", []):
+        assert "start" in entry, (
+            f"{entry} needs 'start'; 'date' is the REST API's spelling"
+        )
+        assert "date" not in entry, f"{entry} must not use 'date'"
+        assert entry.get("type") in DATE_TYPES, (
+            f"{entry.get('type')!r} is not one of {sorted(DATE_TYPES)}"
+        )
+
+
+def test_creators_and_contributors_are_named_family_first(metadata):
+    """Zenodo reads these family-name-first, which is how a contributor
+    once ended up recorded with his given name as his surname."""
+    for group in ("creators", "contributors"):
+        for person in metadata.get(group, []):
+            assert "," in person["name"], (
+                f"{person['name']!r} should read 'Family, Given'"
+            )
+
+
+def test_subjects_carry_a_scheme_and_a_resolvable_identifier(metadata):
+    for entry in metadata.get("subjects", []):
+        assert entry["scheme"] and entry["term"]
+        assert entry["identifier"].startswith("http"), entry

--- a/tools/zenodo_sync.py
+++ b/tools/zenodo_sync.py
@@ -314,9 +314,12 @@ def build_metadata(config, *, with_description=False, release_notes=None):
         metadata["references"] = [{"reference": reference}
                                   for reference in config["references"]]
     if config.get("dates"):
+        # .zenodo.json holds these in the shape Zenodo's release-time
+        # ingestion validates -- "start" and a capitalised type. The API
+        # wants "date" and a lowercase vocabulary id.
         metadata["dates"] = [
-            {"date": entry["date"],
-             "type": {"id": entry["type"]},
+            {"date": entry.get("start") or entry["date"],
+             "type": {"id": entry["type"].lower()},
              **({"description": entry["description"]}
                 if entry.get("description") else {})}
             for entry in config["dates"]]


### PR DESCRIPTION
Fix the .zenodo.json field that failed the 1.2.0 archive

Zenodo reported "Extra metadata load failed" and refused to archive
1.2.0 twice, while returning 202 to the webhook each time -- so the
failure was invisible from GitHub and from the API, and only the
repository's page in Zenodo's settings showed it.

The cause was mine. The dates entry added for the 2016 first commit used
the REST API's shape, {"date": ..., "type": "created"}, in a file Zenodo
validates against its legacy deposit schema, which wants {"start": ...,
"type": "Created"}. Posting the file to Zenodo's own validator confirms
it: metadata.dates, "Invalid date provided." Nothing else in the file
was wrong -- custom_fields, subjects, references, language and the ROR
affiliations all passed.

zenodo_sync translates the legacy shape to the API's, so one file still
describes the deposit for both paths.

tests/test_zenodo_metadata.py checks statically what the validator would
have said: known keys only, dates in the ingestion's shape, names
family-first, subjects carrying a scheme and a resolvable identifier.
A malformed field here does not degrade a deposit, it fails the archive,
and nothing else catches that until after a release has gone out.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
