### PR TITLE
Point CITATION.cff at the 1.2.1 archive

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ identifiers:
     description: >-
       Concept DOI, resolving to the most recent release of the software.
   - type: doi
-    value: 10.5281/zenodo.22152018
+    value: 10.5281/zenodo.22182012
     description: >-
       Archived snapshot of the version this file names. Update it with
       the version, after Zenodo has minted the DOI for the new release.


### PR DESCRIPTION
The post-release step in `RELEASING.md`. The concept DOI never changes; the version DOI names a specific archive and can only be set once Zenodo has minted it — [10.5281/zenodo.22182012](https://doi.org/10.5281/zenodo.22182012).