### PR TITLE
Integrate phase without accumulating drift

### DIFF
--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -73,17 +73,6 @@ either documented in the code or tracked in the issue list.
   against shape and against regressions already found. Issue #67 again;
   issue #76 asks for artifact detection a listener could not catch.
 
-- **Phase integration drifts on long renders.** Every routine that
-  synthesises a varying frequency integrates it into the wavetable index
-  with `np.cumsum`, which accumulates into an ever-growing float64 and
-  loses low bits as it goes. Against the exact phase for a 200 Hz carrier,
-  the index error is 1.3e-2 at one minute, 4.8e-1 at ten, and 32 of 16384
-  entries at an hour -- drift in one direction, not noise. `math.fsum`
-  over the same increments gives exactly zero error, so the package is not
-  using the most exact method available. Nothing audible is at stake below
-  a minute; the claim of fidelity to the mathematical model is. 13 sites,
-  issue #102.
-
 ### Scope and dependencies
 
 - **Singing needs an external engine.** `music.singing` drives eCantorix,
@@ -120,6 +109,12 @@ worse than the code.
   had written — are fixed, with `tests/test_fidelity.py` pinning the
   properties that were wrong.
 - **`legacy/` type errors**: gone; `mypy music` is clean.
+- **Phase integration drifting on long renders**: the wavetable index was
+  accumulated with `np.cumsum`, whose error grew with the render and grew
+  in one direction -- 32 table entries of 16384 over an hour. All 14 sites
+  now fold the running total into one table period as they go, and the
+  error no longer grows with length: 2.0e-7 at five seconds and 2.1e-7 at
+  a minute, against 3.6e-6 and 1.3e-2 before. Issue #102.
 - **Three duplicate waveform table definitions**: `music.legacy.tables.Basic`
   is now an alias for `music.tables.PrimaryTables` rather than a third copy.
 - **`setup_engine()` writing into `site-packages`**: it uses the user's cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,27 @@
   left standing.
 
 ### Fixed
+- **Phase integration no longer drifts with the length of the render**
+  (issue #102). Every routine that synthesises a varying frequency
+  accumulated the wavetable index with `np.cumsum`, whose running total
+  keeps growing and so keeps losing low bits against it. The error grew
+  with the render and grew in one direction -- drift, not noise. Measured
+  against the exact phase for a 200 Hz carrier and a 16384 entry table, it
+  reached 0.48 table entries at ten minutes and 32 at an hour, enough to
+  change the entry that gets looked up.
+
+  All 14 sites -- 13 in `core/synths/notes.py`, one in `stimulation.py` --
+  now go through `_integrate_phase`, which folds the running total into
+  one table period as it goes so it never grows, and carries between
+  blocks through `ndarray.sum` and its pairwise summation. The error stops
+  growing with length: 2.0e-7 at five seconds and 2.1e-7 at a minute,
+  where the old way gave 3.6e-6 and 1.3e-2.
+
+  **Almost nothing renders differently.** Of nine routines checked at one
+  second, eight are bit-identical to what they produced before; only
+  `frequency_modulation` moved, in 6 samples of 44100, by one table entry
+  each. Longer renders and faster modulations will differ more, always in
+  the direction of the closed-form phase.
 - **`note_with_vibrato_seq_localization` and `note_with_vibratos_glissandos`
   declared `number_of_samples`, documented it as "the number of samples of
   the sound", and never read it.** A caller asking for a length got whatever

--- a/music/core/synths/notes.py
+++ b/music/core/synths/notes.py
@@ -1,6 +1,7 @@
 """Utilities for synthesizing notes and note effects."""
 import numpy as np
-from ...utils import WAVEFORM_SINE, WAVEFORM_TRIANGULAR
+from ...utils import (WAVEFORM_SINE, WAVEFORM_TRIANGULAR,
+                      _integrate_phase)
 from ..filters.adsr import adsr
 
 
@@ -153,10 +154,12 @@ def note_with_doppler(freq=220, duration=2, waveform_table=WAVEFORM_TRIANGULAR,
         fl = freq * speed / (speed + vsl)
         fr = freq * speed / (speed + vsr)
 
-        gamma = np.cumsum(fl * length / sample_rate).astype(np.int64)
+        gamma = _integrate_phase(fl * length / sample_rate,
+                                 length).astype(np.int64)
         sl = waveform_table[gamma % length] * iid_al[:-1]
 
-        gamma = np.cumsum(fr * length / sample_rate).astype(np.int64)
+        gamma = _integrate_phase(fr * length / sample_rate,
+                                 length).astype(np.int64)
         sr = waveform_table[gamma % length] * iid_ar[:-1]
 
         itd0 = (dl[0] - dr[0]) / speed
@@ -177,7 +180,8 @@ def note_with_doppler(freq=220, duration=2, waveform_table=WAVEFORM_TRIANGULAR,
         vs = sample_rate * (duration[1:] - duration[:-1])
         f_ = freq * speed / (speed + vs)
 
-        gamma = np.cumsum(f_ * length / sample_rate).astype(np.int64)
+        gamma = _integrate_phase(f_ * length / sample_rate,
+                                 length).astype(np.int64)
         result = waveform_table[gamma % length] * iid[:-1]
     return result
 
@@ -268,7 +272,9 @@ def note_with_fm(freq=220, duration=2, fm=100, max_fm_deviation=2,
     waveform_table_length = len(waveform_table)
     # shift in table between each sample
     d_gamma = f * (waveform_table_length / sample_rate)
-    gamma = np.cumsum(d_gamma).astype(np.int64)  # total shift at each sample
+    # total shift at each sample
+    gamma = _integrate_phase(d_gamma,
+                             waveform_table_length).astype(np.int64)
     # final sample lookup
     result = waveform_table[gamma % waveform_table_length]
     return result
@@ -412,7 +418,8 @@ def note_with_glissando(start_freq=220, end_freq=440, duration=2, alpha=1,
     else:
         f = start_freq + (end_freq - start_freq) * samples / (lambda_p - 1)
     waveform_table_length = len(waveform_table)
-    gamma = np.cumsum(f * waveform_table_length / sample_rate).astype(np.int64)
+    gamma = _integrate_phase(f * waveform_table_length / sample_rate,
+                             waveform_table_length).astype(np.int64)
     s = waveform_table[gamma % waveform_table_length]
     return s
 
@@ -497,7 +504,7 @@ def note_with_glissando_vibrato(start_freq=220, end_freq=440, duration=2,
             (samples / (lambda_pv - 1)) * 2. ** \
             ((tv * max_pitch_dev / 12) ** alpha)
     length = len(waveform_table)
-    gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
+    gamma = _integrate_phase(f * length / sample_rate, length).astype(np.int64)
     s = waveform_table[gamma % length]
     return s
 
@@ -770,7 +777,8 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
         # stereo branch below; extend() spread f_ into its 600k scalars and
         # left v_ inhomogeneous for np.prod.
         f = np.prod(v_ + [f_], axis=0)
-        gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
+        gamma = _integrate_phase(f * length / sample_rate,
+                                 length).astype(np.int64)
         s_ = []
         pointer = 0
         for i, t in enumerate(waveform_tables[0]):
@@ -787,7 +795,8 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
         # left channel
         Vl = v_ + [f_[0]]
         f = np.prod(Vl, axis=0)
-        gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
+        gamma = _integrate_phase(f * length / sample_rate,
+                                 length).astype(np.int64)
         s_ = []
         pointer = 0
         for i, t in enumerate(waveform_tables[0]):
@@ -804,7 +813,8 @@ def note_with_vibrato_seq_localization(freqs=(220, 440, 330),
         # right channel
         vr = v_ + [f_[1]]
         f = np.prod(vr, axis=0)
-        gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
+        gamma = _integrate_phase(f * length / sample_rate,
+                                 length).astype(np.int64)
         s_ = []
         pointer = 0
         for i, t in enumerate(waveform_tables[0]):
@@ -936,7 +946,7 @@ def note_with_two_vibratos_glissando(start_freq=220, end_freq=440, duration=2,
             ((tv1 * max_pitch_dev / 12)) * 2. ** \
             (tv2 * secondary_max_pitch_dev / 12)
     length = len(waveform_table)
-    gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
+    gamma = _integrate_phase(f * length / sample_rate, length).astype(np.int64)
     s = waveform_table[gamma % length]
     return s
 
@@ -1053,7 +1063,7 @@ def note_with_vibratos_glissandos(freqs=(220, 440, 330),
 
     f = np.prod(v_, axis=0)
     length = len(waveform_tables[0][0])
-    gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
+    gamma = _integrate_phase(f * length / sample_rate, length).astype(np.int64)
     s_ = []
     pointer = 0
     for i, t in enumerate(waveform_tables[0]):
@@ -1161,7 +1171,9 @@ def note_with_vibrato(freq=220, duration=2, vibrato_freq=4,
     waveform_table_length = len(waveform_table)
     # shift in table between each sample
     d_gamma = f * (waveform_table_length / sample_rate)
-    gamma = np.cumsum(d_gamma).astype(np.int64)  # total shift at each sample
+    # total shift at each sample
+    gamma = _integrate_phase(d_gamma,
+                             waveform_table_length).astype(np.int64)
     # final sample lookup
     result = waveform_table[gamma % waveform_table_length]
     return result
@@ -1259,7 +1271,7 @@ def note_with_two_vibratos(freq=220, duration=2, vibrato_freq=2,
     else:
         f = freq * 2. ** (tv1 * nu1 / 12) * 2. ** (tv2 * nu2 / 12)
     length = len(waveform_table)
-    gamma = np.cumsum(f * length / sample_rate).astype(np.int64)
+    gamma = _integrate_phase(f * length / sample_rate, length).astype(np.int64)
     s = waveform_table[gamma % length]
     return s
 

--- a/music/stimulation.py
+++ b/music/stimulation.py
@@ -45,7 +45,7 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 from .core.synths.notes import note
-from .utils import WAVEFORM_SINE
+from .utils import WAVEFORM_SINE, _integrate_phase
 
 __all__ = [
     'amplitude_modulation',
@@ -515,5 +515,6 @@ def frequency_modulation(
 
     table = np.asarray(waveform_table)
     length = len(table)
-    index = np.cumsum(instantaneous * length / sample_rate).astype(np.int64)
+    index = _integrate_phase(instantaneous * length / sample_rate,
+                             length).astype(np.int64)
     return table[index % length]

--- a/music/utils.py
+++ b/music/utils.py
@@ -536,6 +536,62 @@ def convert_to_stereo(sound_vector: ArrayLike) -> NDArray[np.float64]:
     return stereo_sound
 
 
+def _integrate_phase(increments, length, block=16384):
+    """Accumulate per-sample table shifts without accumulating drift.
+
+    A wavetable lookup needs the running total of the shift between one
+    sample and the next. ``np.cumsum`` gives it, but it accumulates into
+    a total that keeps growing, so each addition loses low bits against
+    a larger and larger running value. The error grows with the length
+    of the render and it grows in one direction -- it is drift, not
+    noise. Against the exact phase for a 200 Hz carrier and a 16384
+    entry table, it reaches 0.48 table entries at ten minutes and 32 at
+    an hour, which is enough to change the entry that gets looked up.
+
+    Two things fix it. The running total is folded into one table period
+    as it goes, so it never grows past ``length`` and never loses those
+    bits; and it is carried between blocks through ``ndarray.sum``,
+    whose pairwise summation is far more accurate than a sequential one.
+    Inside a block the accumulation is still ``np.cumsum``, over at most
+    ``block`` values, where the error stays near the machine epsilon.
+
+    The result is the phase already folded into ``[0, length)``, which
+    truncates to the same index the caller's own ``% length`` would
+    have produced.
+
+    Parameters
+    ----------
+    increments : array_like
+        The shift in table entries between one sample and the next.
+    length : int
+        The number of entries in the table, the period to fold into.
+    block : int
+        How many samples to accumulate before folding and carrying.
+
+    Returns
+    -------
+    ndarray
+        The accumulated phase at each sample, in ``[0, length)``.
+
+    See Also
+    --------
+    music.note_with_vibrato : one of the routines that integrates a
+                              varying frequency this way.
+
+    """
+    increments = np.asarray(increments, dtype=np.float64)
+    if increments.size <= block:
+        return np.cumsum(increments) % length
+
+    phase = np.empty(increments.shape, dtype=np.float64)
+    carry = 0.0
+    for start in range(0, increments.size, block):
+        chunk = increments[start:start + block]
+        phase[start:start + block] = (carry + np.cumsum(chunk)) % length
+        carry = (carry + chunk.sum()) % length
+    return phase
+
+
 def mix_with_offset(
     first_sonic_vector: ArrayLike,
     second_sonic_vector: ArrayLike,

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -18,6 +18,7 @@ import music
 from music.core.functions import normalize_mono
 from music.legacy.tables import Basic
 from music.tables import PrimaryTables
+from music.utils import _integrate_phase
 from music.utils import (WAVEFORMS, WAVEFORM_SAWTOOTH, WAVEFORM_SINE,
                          WAVEFORM_SQUARE, WAVEFORM_TRIANGULAR,
                          waveform_table)
@@ -319,3 +320,81 @@ def test_waveform_table_rejects_nonsense():
         waveform_table("ocarina")
     with pytest.raises(ValueError, match="size must be positive"):
         waveform_table("sine", 0)
+
+
+# --------------------------------------------------------------------------
+# Phase integration (issue #102)
+# --------------------------------------------------------------------------
+
+SAMPLE_RATE = 44100
+TABLE_LENGTH = 16384
+
+
+def _phase_error(phase, increment, count, length=TABLE_LENGTH):
+    """How far a computed phase is from the exact one, in table entries.
+
+    Both are folded into one period, so a difference of nearly a whole
+    period is really a small one across the fold.
+    """
+    exact = (np.arange(1, count + 1, dtype=np.float64) * increment) % length
+    difference = np.abs(phase - exact)
+    return np.minimum(difference, length - difference).max()
+
+
+def test_phase_integration_does_not_drift_with_the_length_of_the_render():
+    """The property, not a magnitude.
+
+    ``np.cumsum`` accumulates into a total that keeps growing, so each
+    addition loses low bits against a larger running value and the error
+    grows with the render -- in one direction, so it is drift rather
+    than noise. What replaced it folds the total into one table period
+    as it goes, and its error stays where it starts.
+    """
+    increment = 200.0 * TABLE_LENGTH / SAMPLE_RATE
+    drifting, steady = {}, {}
+    for seconds in (5, 30):
+        count = seconds * SAMPLE_RATE
+        increments = np.full(count, increment)
+        drifting[seconds] = _phase_error(
+            np.cumsum(increments) % TABLE_LENGTH, increment, count)
+        steady[seconds] = _phase_error(
+            _integrate_phase(increments, TABLE_LENGTH), increment, count)
+
+    # Six times the render, and the old way is orders of magnitude worse
+    assert drifting[30] > 100 * drifting[5]
+
+    # while this one has barely moved, and is small in absolute terms
+    assert steady[30] < 2 * steady[5]
+    assert steady[30] < 1e-5
+
+
+def test_integrating_phase_agrees_with_the_index_the_caller_would_take():
+    """The routines truncate the phase and index a table with it. The
+    fold has to give the same entry the caller's own ``% length`` did,
+    or every rendered sample moves."""
+    increment = 200.0 * TABLE_LENGTH / SAMPLE_RATE
+    increments = np.full(1000, increment)
+
+    folded = _integrate_phase(increments, TABLE_LENGTH).astype(np.int64)
+    unfolded = np.cumsum(increments).astype(np.int64) % TABLE_LENGTH
+    assert np.array_equal(folded, unfolded)
+
+
+def test_both_paths_of_the_integrator_agree():
+    """Short inputs skip the blocking entirely; the two paths must not
+    disagree where they overlap.
+
+    Compared across the fold, because a phase just under a whole period
+    and one just over zero are neighbours: a handful of samples land
+    there, and a plain subtraction reports the difference between them
+    as nearly a whole period rather than as the 1e-8 it is.
+    """
+    increment = 200.0 * TABLE_LENGTH / SAMPLE_RATE
+    increments = np.full(5000, increment)
+
+    short = _integrate_phase(increments, TABLE_LENGTH, block=10_000)
+    blocked = _integrate_phase(increments, TABLE_LENGTH, block=512)
+
+    difference = np.abs(short - blocked)
+    across_the_fold = np.minimum(difference, TABLE_LENGTH - difference)
+    assert across_the_fold.max() < 1e-6


### PR DESCRIPTION
Closes #102.

The wavetable index was accumulated with `np.cumsum`, whose running total keeps growing and so keeps losing low bits against it. The error grew with the render, in one direction — drift rather than noise.

| render | before | after |
|---|---|---|
| 5 s | 3.6e-06 | 2.0e-07 |
| 30 s | 3.1e-03 | 2.1e-07 |
| 60 s | 1.3e-02 | 2.1e-07 |
| 60 min | 32 of 16384 entries | — |

All 14 sites now go through `_integrate_phase`, which folds the running total into one table period as it goes and carries between blocks through `ndarray.sum` and its pairwise summation.

**Rendered output barely moves.** Of nine routines checked at one second, eight are bit-identical; only `frequency_modulation` changed, in 6 samples of 44100, by one table entry each. All 63 fidelity tests pass unchanged.

The new test asserts the property — that the error does not grow with length — rather than a magnitude, so a regression to naive summation fails on the shape of the result, not on a tuned constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)