### PR TITLE
Cut 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
-## [Unreleased]
+## [1.3.0] - 2026-09-01
+### Note for anyone upgrading
+**Nothing that imports from `music` breaks.** Two functions were renamed
+for saying what they do -- `mix2` is now `mix_many` and `mix_with_offset_`
+is now `mix_many_with_offsets` -- and both old names stay bound to the new
+functions.
+
+Two things do render differently, in both cases because they were wrong
+before:
+
+- `note_with_vibrato_seq_localization` and `note_with_vibratos_glissandos`
+  now honour `number_of_samples`, which they had declared, documented and
+  ignored. Code that passed it was getting a sound of whatever length the
+  durations summed to; it now gets the length it asked for.
+- Phase is integrated without accumulating drift. Of nine routines checked
+  at one second, eight are bit-identical to 1.2.1; only long renders and
+  fast modulations differ, and always towards the closed-form phase.
+
+New: `music.stimulation`, five auditory stimuli named for the SSTIM
+techniques they implement, and the `WAVEFORM_*` tables are now re-exported
+from the top level.
 
 ### Added
 - **The wavetables are re-exported from the top level**: `WAVEFORM_SINE`,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ message: >-
   If you use this package, please cite the article under
   preferred-citation, as the documentation asks.
 type: software
-version: 1.2.1
-date-released: '2026-08-31'
+version: 1.3.0
+date-released: '2026-09-01'
 license: MIT
 repository-code: https://github.com/ttm/music
 identifiers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'music'
-version = '1.2.1'
+version = '1.3.0'
 authors = [
     { name = 'Renato Fabbri', email = 'renato.fabbri@gmail.com' },
     { name = 'Jacopo Donati', email = 'jacopo.donati@gmail.com' }


### PR DESCRIPTION
Version bumped in `pyproject.toml` and `CITATION.cff`, `date-released` set to 2026-09-01, and the changelog's `Unreleased` entries moved under the new heading.

**Minor, not patch.** The release adds `music.stimulation` and six wavetable exports, renames two mixers while keeping the old names bound, and changes what two routines render:

- `note_with_vibrato_seq_localization` and `note_with_vibratos_glissandos` now honour `number_of_samples`, which they had declared, documented and ignored.
- Phase is integrated without accumulating drift (#102). Eight of nine routines checked at one second are bit-identical to 1.2.1.

Nothing that imports from `music` breaks: `mix2` and `mix_with_offset_` stay bound to `mix_many` and `mix_many_with_offsets`.

Publishing to PyPI, GitHub and Zenodo follows from `master` once this merges, per RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)