### PR TITLE
Finish the stimulation toolkit: two stimuli, and protocols

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -60,7 +60,12 @@
     "computer music",
     "Python",
     "numpy",
-    "MASS framework"
+    "MASS framework",
+    "sensory stimulation",
+    "auditory entrainment",
+    "binaural beats",
+    "isochronic tones",
+    "SSTIM"
   ],
   "subjects": [
     {
@@ -112,6 +117,26 @@
       "term": "Acoustics",
       "scheme": "EuroSciVoc",
       "identifier": "http://data.europa.eu/8mn/euroscivoc/273"
+    },
+    {
+      "term": "Music Therapy",
+      "scheme": "MeSH",
+      "identifier": "https://id.nlm.nih.gov/mesh/D009147"
+    },
+    {
+      "term": "Music Therapy/methods",
+      "scheme": "MeSH",
+      "identifier": "https://id.nlm.nih.gov/mesh/D009147Q000379"
+    },
+    {
+      "term": "Music Therapy/standards",
+      "scheme": "MeSH",
+      "identifier": "https://id.nlm.nih.gov/mesh/D009147Q000592"
+    },
+    {
+      "term": "Acoustic Stimulation",
+      "scheme": "MeSH",
+      "identifier": "https://id.nlm.nih.gov/mesh/D000161"
     }
   ],
   "dates": [

--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -1,8 +1,8 @@
 # Quality assessment and known limitations
 
-*A living record, not a point-in-time audit. Last measured **2026-08-31**,
-`music` 1.2.1 at commit `be7990a`: 37 modules, 7,431 LOC package + 3,888 LOC
-tests, 73 names in the public API.*
+*A living record, not a point-in-time audit. Last measured **2026-09-02**,
+`music` 1.3.0 plus the unreleased sensory-stimulation toolkit: 40 modules,
+8,736 LOC package + 4,753 LOC tests, 88 names in the public API.*
 
 The first version of this file graded the repository once, in August 2026,
 and was already stale four days later: it reported 125 tests at 61 % coverage
@@ -21,15 +21,16 @@ Every figure below came from running the code, not from reading it.
 
 | Check | Command | Result |
 |---|---|---|
-| Test suite | `pytest -q` | **504 passed**, 18 s |
-| Coverage | `pytest --cov=music --cov-fail-under=100` | **100 %** (2,080 stmts, 0 missed) |
-| Type check | `mypy music` | **clean**, 37 files |
+| Test suite | `pytest -q` | **586 passed**, 13 s |
+| Coverage | `pytest --cov=music --cov-fail-under=100` | **100 %** (2,288 stmts, 0 missed) |
+| Type check | `mypy music` | **clean**, 40 files |
 | Lint | `ruff check music tests examples tools conftest.py` | **clean** |
-| Lint, extended rule set | `ruff check --select ALL music` | 1,554 findings |
-| Annotation coverage | AST scan | **31 / 140 functions (22 %)** |
-| Docstring coverage | AST scan | **126 / 133 public defs (95 %)** |
-| Examples | run all 10 | **9 pass**, 1 needs the external singing engine |
+| Lint, extended rule set | `ruff check --select ALL music` | 1,705 findings |
+| Annotation coverage | AST scan | **43 / 159 functions (27 %)** |
+| Docstring coverage | AST scan | **139 / 146 public defs (95 %)** |
+| Examples | run all 11 | **10 pass**, 1 needs the external singing engine |
 | Public API | `tests/test_public_api.py` | every export callable on its own defaults |
+| Archival subjects | NLM MeSH lookup, per identifier | every term in `.zenodo.json` resolves to the term it declares |
 
 `mypy` runs with `check_untyped_defs = true`, so it inspects function bodies
 rather than skipping the unannotated ones — which is most of them. A clean
@@ -43,8 +44,8 @@ produced.
 | **Exceptional** | Docstrings and scientific grounding: every routine carries the equation it implements and the article section it comes from |
 | **Excellent** | Conceptual architecture; breadth of synthesis primitives; the release and archival process, which is reproducible and produces a citable DOI per version |
 | **Very good** | Test suite and its coverage gate; CI across Python 3.10–3.14 including a job pinned to the declared lower bounds |
-| **Good** | Curated flat public API; examples; published API reference |
-| **Needs work** | Annotation coverage at 22 %; the `legacy/` subpackage; `core/functions.py` not yet reconciled with the MASS reference implementation |
+| **Good** | Curated flat public API; examples; published API reference; the sensory-stimulation toolkit, whose stimuli are each tested against the property that defines them rather than against their shape |
+| **Needs work** | Annotation coverage at 27 %; the `legacy/` subpackage; `core/functions.py` not yet reconciled with the MASS reference implementation |
 
 ## Known limitations
 
@@ -60,11 +61,14 @@ either documented in the code or tracked in the issue list.
 
 ### Gaps the code names about itself
 
-- **No head-related transfer function.** Both `localize` and `localize2` say
-  so in their own notes: the height of a source, and whether it is in front
-  of or behind the listener, are cues an HRTF carries and neither models.
-  This is the largest genuine gap in the package, and it is research-scale
-  work rather than a fix.
+- **No head-related transfer function.** `localize`, `localize2`,
+  `localize_linear` and `spatial_motion` all say so in their own notes: the
+  height of a source, and whether it is in front of or behind the listener,
+  are cues an HRTF carries and none of them models. Concretely, azimuths of
+  90° and −90° — ahead and behind — render the same two channels, and a test
+  now asserts that they do, so adding an HRTF will announce itself by
+  breaking it. This is the largest genuine gap in the package, and it is
+  research-scale work rather than a fix.
 - **`core/functions.py` has not been reconciled, routine by routine, with
   the MASS reference implementation.** The package's central claim is
   fidelity to a published framework; until that pass is done, the claim
@@ -72,6 +76,27 @@ either documented in the code or tracked in the issue list.
 - **Rendering is not verified against the mathematics it documents**, only
   against shape and against regressions already found. Issue #67 again;
   issue #76 asks for artifact detection a listener could not catch.
+
+### Claims the metadata makes that the code cannot
+
+- **The stimulation toolkit renders stimuli; it does not demonstrate that
+  they do anything.** Every routine in `music.stimulation` is tested against
+  the property that defines it — a binaural beat has no beat in either
+  channel, an isochronic train gates at the rate asked for, an
+  amplitude-modulated carrier puts its envelope where it said it would — and
+  those tests are about the signal, which is all a synthesis library can
+  speak to. Whether a 10 Hz stimulus entrains anything in a listener is a
+  question for the literature the SSTIM terms point at, not for this
+  repository. The `Music Therapy` subjects in `.zenodo.json` and the
+  `Intended Audience :: Healthcare Industry` classifier say what the package
+  is *for*; they are not evidence of efficacy, and nothing here should be
+  read as clinical.
+- **Speaking SSTIM is currently a matter of docstrings.** Each stimulus
+  names the SSTIM technique it implements and links its IRI, and
+  `StimulationSession` borrows that model's vocabulary, but the package
+  cannot yet read an `sstim:StimulusSpecification` or emit one. Until it
+  can, the correspondence is documented rather than machine-checkable.
+  Issue #75.
 
 ### Scope and dependencies
 
@@ -86,11 +111,11 @@ either documented in the code or tracked in the issue list.
 
 ### Debt that is not breakage
 
-- **Annotation coverage is 22 %.** The package type-checks cleanly with
+- **Annotation coverage is 27 %.** The package type-checks cleanly with
   bodies inspected, so this is missing documentation of intent rather than
   missing safety.
-- **The extended lint set reports 1,554 findings** on `music/`, almost all
-  stylistic: 368 missing argument annotations, 286 quote-style, 92 missing
+- **The extended lint set reports 1,705 findings** on `music/`, almost all
+  stylistic: 389 missing argument annotations, 330 quote-style, 92 missing
   return annotations. The configured set — `E`, `W`, `F` — is clean. The
   gap between the two is a deliberate choice about which rules earn their
   noise, not an oversight.
@@ -117,6 +142,14 @@ worse than the code.
   a minute, against 3.6e-6 and 1.3e-2 before. Issue #102.
 - **Three duplicate waveform table definitions**: `music.legacy.tables.Basic`
   is now an alias for `music.tables.PrimaryTables` rather than a third copy.
+- **`localize_linear`'s worked example moved nothing.** It passed
+  `theta1=90, theta2=-90` and called it a pass from the left to the right,
+  but this package measures azimuth from the ear axis, so both angles sit on
+  the median plane and the example rendered two identical channels. Anyone
+  who copied it got a mono sound in a stereo file. The example is corrected
+  and the convention is now stated rather than left to be inferred — an
+  instance of exactly what issue #67 exists to find, caught by writing a
+  test that expected the documented behaviour and getting silence.
 - **`setup_engine()` writing into `site-packages`**: it uses the user's cache
   directory, which survives an upgrade and works on a read-only install.
 - **No published API docs**: they are at <https://ttm.github.io/music/>,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,84 @@
+## [Unreleased]
+### Note for anyone upgrading
+**Nothing that imports from `music` breaks, and nothing renders
+differently.** `music.stimulation` became a package rather than a single
+module, and every name it exported is still imported from the same
+place. `localize_linear` is bit-identical to 1.3.0; what changed there
+is the example in its docstring, which was wrong -- see below.
+
+### Added
+- **`music.modulated_noise`**, broadband noise of a chosen colour,
+  optionally amplitude-modulated. Unmodulated it is the continuous
+  broadband stimulus SSTIM catalogues as `techBroadbandNoise`, the
+  vehicle for stochastic resonance and for masking; modulated it is also
+  `techAmplitudeModulation`, whose definition names a carrier tone *or
+  noise*. The distinction is in the signal and not only in the label: at
+  a rate of zero there is no envelope to find, and the test says so.
+- **`music.spatial_motion`**, a source orbiting the listener at a chosen
+  rate, rendering `sstim-v:techSpatialAuditory`. SSTIM distinguishes
+  structured spatial trajectories from simple left/right crossfades, and
+  this is on the right side of that line: the interaural time and
+  intensity differences are computed per sample from the geometry. It
+  will move a sound it did not synthesize, so a noise bed or an already
+  rendered stimulus can be given a trajectory.
+- **`music.StimulationSession`**, a protocol: phases in order, each with
+  its own stimulus, duration and gain, joined by crossfades rather than
+  by cuts. **The session lasts exactly the sum of its phase durations.**
+  A ramp is taken half from the phase before it and half from the phase
+  after, so a transition is centred on the boundary instead of being
+  inserted between the phases and stretching the protocol past the
+  length its author wrote down -- ten minutes of stimulation stays ten
+  minutes. Boundaries are rounded from elapsed time rather than summed
+  from per-phase roundings, which is the same drift the phase
+  integration carried until 1.3.0 and would have cost a long session
+  several samples of length.
+
+  Phases that disagree about channels are reconciled by promoting the
+  session to stereo, never by flattening, because flattening is exactly
+  what destroys a binaural beat. Crossfades are equal-power by default,
+  since two different stimuli are uncorrelated and a linear pair would
+  dig a 3 dB hole at every transition; `ramp_shape='linear'` is there
+  for the correlated case, where it is the flat one instead.
+
+### Fixed
+- **`localize_linear`'s example moved nothing.** It read
+  `theta1=90, theta2=-90` and called it "a pass from the left to the
+  right", but the azimuth in this package is measured from the ear axis:
+  0 is the right ear's side and 180 the left, so 90 and -90 are both on
+  the median plane, ahead and behind. Both render the same distance to
+  both ears, so the example produced two identical channels and no
+  movement whatsoever. The example is now `theta1=180, theta2=0`, and
+  the convention is stated in the function's notes rather than left to
+  be inferred. Anyone who copied that example was writing a mono sound
+  into two channels.
+
+  That the two are indistinguishable is not itself a defect -- front
+  from back is an HRTF cue and this package has no HRTF, which it says
+  in several places. A test now pins it -- ahead and behind
+  must render the same two channels -- so that if an HRTF is ever
+  added, that test fails and the notice arrives with it.
+
+### Changed
+- **The MeSH music-therapy subjects are back in `.zenodo.json`**, along
+  with `Acoustic Stimulation`. They were removed at 1.2.0 as a claim the
+  code did not back; the toolkit backs it now, and the same reasoning
+  applies in reverse. `Intended Audience :: Healthcare Industry`, which
+  had been in `pyproject.toml` making that claim on its own, is earned
+  for the first time. Every MeSH identifier in the file was checked
+  against the NLM lookup service and resolves to the term it declares.
+- **`HRTF` is no longer a keyword in `pyproject.toml`.** There is no
+  head-related transfer function in this package -- `ASSESSMENT.md`
+  calls its absence the largest genuine gap -- and a keyword that
+  surfaces the package in searches it can only disappoint is the same
+  mistake the music-therapy subjects were, in the other direction.
+- **`music.stimulation` is a package** rather than a single module, with
+  the generators in `stimulation/stimuli.py` and the session in
+  `stimulation/session.py`. Import paths are unchanged.
+- **`localize_linear` and `spatial_motion` share their localization
+  math** through `_localize_positions`, rather than the second one
+  carrying a second copy of it. A source held still by either renders
+  identically, and a test asserts it.
+
 ## [1.3.0] - 2026-09-01
 ### Note for anyone upgrading
 **Nothing that imports from `music` breaks.** Two functions were renamed

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ with the equation it implements and the article it comes from.
   mathematical model that describes it.
 * **Musical structures** with an emphasis on symmetry and discourse:
   permutation groups, change-ringing peals and plain changes.
+* **Sensory stimulation.** Seven auditory stimuli -- binaural, monaural and
+  isochronic beats, amplitude and frequency modulation, modulated noise and
+  spatial motion -- each named for the technique it implements in
+  [SSTIM](https://w3id.org/sstim), the Sensory Stimulation Vocabulary, and a
+  `StimulationSession` that renders a protocol of them: phases in order,
+  crossfaded rather than cut, lasting exactly the sum of the durations you
+  wrote down. The sample-accurate synthesis is the point here, because the
+  frequency difference *is* the stimulus.
 * **`play_audio`** to listen to a result without saving a file.
 
 Music can be used alone or with other packages, and it is well suited to the
@@ -157,6 +165,7 @@ Inside [the examples folder](https://github.com/ttm/music/tree/master/examples) 
 * [isynth](https://github.com/ttm/music/tree/master/examples/isynth.py) also uses a synth class, but of a different kind, [`IteratorSynth`](https://github.com/ttm/music/tree/master/music/legacy/classes.py), that iterates through arbitrary lists of variables.
 * [singing_demo](https://github.com/ttm/music/tree/master/examples/singing_demo.py): demonstrates `music.singing.setup_engine()` and `music.singing.make_test_song()` to render a short sung phrase.
 * [binaural_beats](https://github.com/ttm/music/tree/master/examples/binaural_beats.py): generates binaural beats using two pure tones with tremolo for relaxation or focus.
+* [sensory_stimulation](https://github.com/ttm/music/tree/master/examples/sensory_stimulation.py): writes one file per SSTIM technique with `music.stimulation`, and one three-phase session, which is the form these stimuli are actually delivered in.
 * The `music.singing` module provides basic text-to-speech utilities. Run `music.singing.setup_engine()` once to clone the [eCantorix](https://github.com/ttm/ecantorix) engine before using these features. It is cloned into your user cache directory; set `MUSIC_ECANTORIX_DIR` to put it elsewhere. Because eCantorix is a Perl program driving espeak through a Makefile, it also needs `git`, `make`, `perl` and `espeak` installed on the system — `setup_engine()` will tell you which are missing.
 
 ## Package structure
@@ -170,6 +179,7 @@ The modules are:
   * **functions** for normalization.
 * **structures** for higher level musical structures: permutations and the algebraic groups they form, change-ringing peals, and symmetry. Scales, chords, counterpoint and tunings are [not there yet](https://github.com/ttm/music/issues/1).
 * **legacy** for musical pieces that are rendered with the Music package and might be used as material to make more music.
+* **stimulation** for sensory-stimulation work: the seven stimuli above, each carrying the SSTIM term it implements, and `StimulationSession` for sequencing them into a protocol.
 * **tables** for the generation of lookup tables for some basic waveform.
 * **utils** for various functions regarding conversions, mix, etc.
 * **sequencer** for scheduling notes into a timeline and exporting audio.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,6 +51,20 @@ by the listener.
    isochronic_tones
    amplitude_modulation
    frequency_modulation
+   modulated_noise
+   spatial_motion
+
+A protocol is a sequence of those rather than one of them.
+:class:`~music.StimulationSession` holds that sequence and renders it as
+one sound, joining the phases with crossfades centred on their boundaries
+so that the session lasts exactly the sum of the durations it was given.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   StimulationSession
+   StimulusPhase
 
 Envelopes and noise
 ~~~~~~~~~~~~~~~~~~~

--- a/examples/sensory_stimulation.py
+++ b/examples/sensory_stimulation.py
@@ -5,11 +5,15 @@ Stimulation Vocabulary (https://w3id.org/sstim), and the docstrings in
 `music.stimulation` name the term each one corresponds to.
 
 The important difference between them is not how they sound but where
-the modulation lives. Four of the five put a real modulation into the
+the modulation lives. Six of the seven put a real modulation into the
 air, and it is present in the rendered file. The binaural beat does
 not: each channel holds a steady tone, and the beat exists only for a
 listener hearing both, which is why it alone must be heard over
 headphones.
+
+The last file is not a stimulus but a protocol: a session of three
+phases, crossfaded rather than cut, which is the form these stimuli are
+actually delivered in.
 """
 
 import music
@@ -52,4 +56,37 @@ music.write_wav_mono(
                                frequency_deviation=20, duration=DURATION),
     "stim_fm.wav")
 
-print("wrote five stimuli, one per SSTIM technique")
+# Noise rather than a tone as the carrier. With no rate this is the
+# plain broadband stimulus SSTIM types as a non-entrainment technique;
+# with one it is amplitude modulation, whose definition names a carrier
+# tone *or noise*.
+music.write_wav_mono(
+    music.modulated_noise(noise_type="pink", modulation_freq=RATE,
+                          modulation_depth=0.8, duration=DURATION),
+    "stim_noise.wav")
+
+# A source orbiting the head. The angle is measured from the ear axis:
+# 180 is the left ear's side and 0 the right, so this crosses the head
+# and returns, four times over the eight seconds.
+music.write_wav_stereo(
+    music.spatial_motion(carrier_freq=CARRIER, motion_rate=0.5,
+                         theta1=180, theta2=0, duration=DURATION),
+    "stim_spatial.wav")
+
+# A protocol, which is what these are delivered as: settle at 7 Hz,
+# descend to 4, and rest under a noise bed. The ramps are crossfades
+# centred on each boundary, so the session lasts exactly the 24 seconds
+# its phases add up to -- a protocol that says eight minutes should not
+# render 7:58 because it spent time fading.
+session = music.StimulationSession(end_ramp=2.0)
+session.add(music.binaural_beats, duration=DURATION, ramp=1.0,
+            label="settle", carrier_freq=CARRIER, beat_freq=RATE)
+session.add(music.isochronic_tones, duration=DURATION, ramp=2.0,
+            label="descend", carrier_freq=CARRIER, pulse_rate=4.0,
+            ramp_duration=0.005)
+session.add(music.modulated_noise, duration=DURATION, ramp=2.0,
+            gain=0.6, label="rest", noise_type="pink", modulation_freq=4.0)
+session.write("stim_session.wav")
+
+print("wrote seven stimuli, one per SSTIM technique, and a session")
+print(f"session: {session!r}")

--- a/music/__init__.py
+++ b/music/__init__.py
@@ -76,11 +76,15 @@ from .core import (
 )
 from .tables import PrimaryTables
 from .stimulation import (
+    StimulationSession,
+    StimulusPhase,
     amplitude_modulation,
     binaural_beats,
     frequency_modulation,
     isochronic_tones,
+    modulated_noise,
     monaural_beats,
+    spatial_motion,
 )
 from .structures import (
     dist,
@@ -102,11 +106,15 @@ __all__ = [
     'WAVEFORM_SQUARE',
     'WAVEFORM_TRIANGULAR',
     'waveform_table',
+    'StimulationSession',
+    'StimulusPhase',
     'amplitude_modulation',
     'binaural_beats',
     'frequency_modulation',
     'isochronic_tones',
+    'modulated_noise',
     'monaural_beats',
+    'spatial_motion',
     '__version__',
     'adsr_stereo',
     'adsr_vibrato',

--- a/music/core/filters/localization.py
+++ b/music/core/filters/localization.py
@@ -151,6 +151,65 @@ def _delayed(signal, delay):
                 3 * (at - after) + beyond - before)))
 
 
+def _localize_positions(sonic_vector, xpos, ypos, zeta, air_temp,
+                        sample_rate):
+    """Apply the binaural cues of an arbitrary per-sample trajectory.
+
+    :func:`localize_linear` walks a straight line and
+    :func:`music.spatial_motion` walks a periodic one, but from the
+    positions onwards the two do the same thing, so they do it here
+    rather than each in its own copy.
+
+    Parameters
+    ----------
+    sonic_vector : ndarray
+        A one-dimensional array with the PCM samples of the sound.
+    xpos, ypos : ndarray
+        The source's coordinates at each sample, in meters, the same
+        length as `sonic_vector`.
+    zeta : scalar
+        The distance between the ears in meters.
+    air_temp : scalar
+        The temperature in Celsius used for calculating the speed of
+        sound.
+    sample_rate : integer
+        The sample rate.
+
+    Returns
+    -------
+    ndarray
+        A (2, nsamples) array with the PCM samples of the stereo sound.
+
+    Notes
+    -----
+    Both cues are measured against the nearer ear at each sample, so the
+    nearer ear is heard undelayed and unattenuated and only the
+    *difference* between the ears is applied. The propagation delay
+    common to both is not, so the result stays aligned with its input
+    and keeps its length.
+    """
+    speed = 331.3 + .606 * air_temp
+
+    # The distance from each ear at each sample.
+    dist_l = np.sqrt((xpos + zeta / 2) ** 2 + ypos ** 2)
+    dist_r = np.sqrt((xpos - zeta / 2) ** 2 + ypos ** 2)
+    nearest = np.minimum(dist_l, dist_r)
+
+    # IID: the nearer ear is heard in full, the farther one attenuated by
+    # how much farther it is.
+    iid_l = nearest / dist_l
+    iid_r = nearest / dist_r
+
+    # ITD: likewise, only the extra distance to the farther ear becomes a
+    # delay, so the nearer ear is undelayed and the sound stays in step
+    # with its input.
+    delay_l = (dist_l - nearest) * sample_rate / speed
+    delay_r = (dist_r - nearest) * sample_rate / speed
+
+    return np.vstack((_delayed(sonic_vector, delay_l) * iid_l,
+                      _delayed(sonic_vector, delay_r) * iid_r))
+
+
 def localize_linear(sonic_vector=None, theta1=90, theta2=0, dist=.1,
                     zeta=0.215, air_temp=20, sample_rate=44100):
     """
@@ -195,13 +254,21 @@ def localize_linear(sonic_vector=None, theta1=90, theta2=0, dist=.1,
     --------
     >>> write_wav_stereo(localize_linear(note(duration=3)))
     >>> # a pass from the left to the right and back
-    >>> horizontal_stack(localize_linear(note(), theta1=90, theta2=-90),
-    ...                  localize_linear(note(), theta1=-90, theta2=90))
+    >>> horizontal_stack(localize_linear(note(), theta1=180, theta2=0),
+    ...                  localize_linear(note(), theta1=0, theta2=180))
 
     Notes
     -----
     The path is a straight line between the two positions, not an arc, which
     is what makes it linear.
+
+    **The angle is measured from the ear axis, not from straight ahead.**
+    Zero degrees is the right ear's side, 180 the left, and 90 and -90 are
+    both on the median plane -- ahead and behind. Two positions that differ
+    only in whether they are in front or behind therefore render
+    identically, because the cue that separates them is one an HRTF carries
+    and this does not; see :func:`localize2` for the same gap stated there.
+    A pass across the head is ``theta1=180, theta2=0``.
 
     Both cues are measured against the nearer ear at each sample, as
     :func:`localize` measures them against the nearer ear of its one fixed
@@ -240,7 +307,6 @@ def localize_linear(sonic_vector=None, theta1=90, theta2=0, dist=.1,
     theta2 = 2 * np.pi * theta2 / 360
     x1, y1 = np.cos(theta1) * dist, np.sin(theta1) * dist
     x2, y2 = np.cos(theta2) * dist, np.sin(theta2) * dist
-    speed = 331.3 + .606 * air_temp
 
     # The position at each sample, moving in a straight line. The divisor
     # is guarded so a single-sample input stays at its starting point.
@@ -249,24 +315,8 @@ def localize_linear(sonic_vector=None, theta1=90, theta2=0, dist=.1,
     xpos = x1 + (x2 - x1) * progress
     ypos = y1 + (y2 - y1) * progress
 
-    # The distance from each ear at each sample.
-    dist_l = np.sqrt((xpos + zeta / 2) ** 2 + ypos ** 2)
-    dist_r = np.sqrt((xpos - zeta / 2) ** 2 + ypos ** 2)
-    nearest = np.minimum(dist_l, dist_r)
-
-    # IID: the nearer ear is heard in full, the farther one attenuated by
-    # how much farther it is.
-    iid_l = nearest / dist_l
-    iid_r = nearest / dist_r
-
-    # ITD: likewise, only the extra distance to the farther ear becomes a
-    # delay, so the nearer ear is undelayed and the sound stays in step
-    # with its input.
-    delay_l = (dist_l - nearest) * sample_rate / speed
-    delay_r = (dist_r - nearest) * sample_rate / speed
-
-    return np.vstack((_delayed(sonic_vector, delay_l) * iid_l,
-                      _delayed(sonic_vector, delay_r) * iid_r))
+    return _localize_positions(sonic_vector, xpos, ypos, zeta, air_temp,
+                               sample_rate)
 
 
 def localize2(sonic_vector=None, theta=-70, x=.1, y=.01, zeta=0.215,

--- a/music/stimulation/__init__.py
+++ b/music/stimulation/__init__.py
@@ -1,0 +1,73 @@
+"""Auditory stimuli for sensory-stimulation work.
+
+Each routine here renders one technique catalogued in **SSTIM**, the
+Sensory Stimulation Vocabulary developed in the W3C Sensory Stimulation
+Vocabulary Community Group. Every function names the SSTIM term it
+implements and links its IRI, so a rendered stimulus can be described in
+the same words a protocol, a dataset or a device uses:
+
+===============================  ==========================================
+Function                         SSTIM technique
+===============================  ==========================================
+:func:`binaural_beats`           ``sstim-v:techBinauralBeats``
+:func:`monaural_beats`           ``sstim-v:techMonauralBeats``
+:func:`isochronic_tones`         ``sstim-v:techIsochronicTones``
+:func:`amplitude_modulation`     ``sstim-v:techAmplitudeModulation``
+:func:`frequency_modulation`     ``sstim-v:techFrequencyModulation``
+:func:`modulated_noise`          ``sstim-v:techBroadbandNoise``
+:func:`spatial_motion`           ``sstim-v:techSpatialAuditory``
+===============================  ==========================================
+
+with ``sstim-v:`` standing for ``https://w3id.org/sstim/vocab#``. All
+seven are members of ``sstim-v:TechniqueScheme``; the last two are typed
+there as non-entrainment techniques, which is a claim about what they do
+rather than about how they are built.
+
+One distinction SSTIM draws is worth carrying into the code, because it
+decides what a recording of the output contains. SSTIM records on each
+rendering mechanism whether it *puts a signal physically into the world*
+or whether the signal is *constructed by the nervous system*. Six of
+these seven put a real modulation into the air, and a spectrum of the
+rendered audio shows it. :func:`binaural_beats` does not: each ear
+receives a steady tone, neither channel contains the beat, and the beat
+exists only for a listener hearing both. Measure the file and it is not
+there. Each docstring states which case it is.
+
+A protocol is a sequence of these rather than one of them, and
+:class:`StimulationSession` is that sequence: phases in order, each with
+its own stimulus and duration, joined by ramps rather than by cuts.
+
+These routines build on the package's own primitives and follow its
+sample-by-sample model: a modulator is folded into the wavetable lookup
+rather than applied to a finished sound.
+
+References
+----------
+.. [1] Fabbri, Renato, et al. "Musical elements in the discrete-time
+       representation of sound." arXiv preprint arXiv:abs/1412.6853 (2017)
+.. [2] SSTIM, the Sensory Stimulation Vocabulary.
+       https://w3id.org/sstim
+"""
+
+from .session import StimulationSession, StimulusPhase
+from .stimuli import (
+    amplitude_modulation,
+    binaural_beats,
+    frequency_modulation,
+    isochronic_tones,
+    modulated_noise,
+    monaural_beats,
+    spatial_motion,
+)
+
+__all__ = [
+    'StimulationSession',
+    'StimulusPhase',
+    'amplitude_modulation',
+    'binaural_beats',
+    'frequency_modulation',
+    'isochronic_tones',
+    'modulated_noise',
+    'monaural_beats',
+    'spatial_motion',
+]

--- a/music/stimulation/session.py
+++ b/music/stimulation/session.py
@@ -1,0 +1,344 @@
+"""Protocols: sequences of stimuli, joined by ramps rather than by cuts.
+
+A stimulation protocol is rarely one stimulus. It is a few of them in
+order -- settle at 10 Hz, descend to 6, rest -- and the interesting part
+is the joins, because a cut between two stimuli is a step discontinuity
+and a step is a click. :class:`StimulationSession` holds that sequence
+and renders it as one sound.
+
+SSTIM calls the reproducible description of an intended run a
+``sstim:SessionSpecification``: "the unit of scientific reproducibility:
+given a specification and a conforming engine, the acoustic output is
+fully determined." That is the object this class is the rendering half
+of. The phases correspond to what SSTIM models as the audible layers of
+a configuration, ``sstim:AudioTrack`` -- "an isochronic tone, a binaural
+carrier pair, a plain carrier, noise" -- taken in sequence rather than
+in parallel.
+
+Teaching this class to *read and write* those descriptions is separate
+work, tracked as issue #75; the vocabulary is adopted here so that the
+two do not have to be reconciled later.
+
+References
+----------
+.. [1] SSTIM, ``SessionSpecification``.
+       https://w3id.org/sstim/session
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Union
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from ..core.io import write_wav_mono, write_wav_stereo
+from ..utils import convert_to_stereo
+
+__all__ = ['StimulationSession', 'StimulusPhase']
+
+Stimulus = Union[Callable[..., ArrayLike], ArrayLike]
+
+
+@dataclass
+class StimulusPhase:
+    """One phase of a session: a stimulus, for a while, ramped into.
+
+    Attributes
+    ----------
+    stimulus : callable or array_like
+        What to render. A callable is called with ``number_of_samples``
+        and ``sample_rate`` alongside ``parameters``, which is what
+        every generator in :mod:`music.stimulation` accepts, so the
+        session can render it at exactly the length the arrangement
+        needs. An array is taken as it stands.
+    duration : scalar
+        How long the phase lasts, in seconds, not counting its share of
+        the ramps at either end. Ignored when ``stimulus`` is an array,
+        which brings its own length.
+    ramp : scalar
+        The length in seconds of the transition *into* this phase: a
+        crossfade with the phase before it, or a fade in from silence
+        for the first phase.
+    gain : scalar
+        A factor applied to the phase before it is mixed, for balancing
+        stimuli of different loudness against each other.
+    label : string
+        A name for the phase, carried for the reader's sake and shown
+        in the session's ``repr``.
+    parameters : dict
+        Keyword arguments passed to ``stimulus`` when it is a callable.
+    """
+
+    stimulus: Stimulus
+    duration: float = 0.0
+    ramp: float = 0.0
+    gain: float = 1.0
+    label: str = ''
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+
+def _ramp_shape(count, shape, rising):
+    """A gain curve `count` samples long, rising or falling.
+
+    Two stimuli of a protocol are different sounds rather than the same
+    sound twice, so their crossfade is between uncorrelated signals,
+    where amplitudes add in quadrature. A linear pair of ramps then dips
+    about 3 dB in the middle -- audible as a hole at every transition --
+    and the sine/cosine pair does not, which is why it is the default.
+    ``'linear'`` is offered for the correlated case, where it is the
+    pair that holds amplitude constant instead.
+    """
+    if count <= 0:
+        return np.ones(0)
+    progress = np.arange(count) / count
+    if not rising:
+        progress = 1 - progress
+    if shape == 'linear':
+        return progress
+    return np.sin(progress * np.pi / 2)
+
+
+@dataclass
+class StimulationSession:
+    """A sequence of stimuli rendered as one sound.
+
+    Phases are added in order and rendered end to end. Each transition
+    is a crossfade centred on the boundary between the phases it joins,
+    so **the session lasts exactly the sum of its phase durations**: a
+    ramp is taken half from the phase before it and half from the phase
+    after, rather than being inserted between them and stretching the
+    protocol past the length its author wrote down. A protocol that says
+    ten minutes lasts ten minutes.
+
+    Attributes
+    ----------
+    sample_rate : integer
+        The sampling frequency in Hertz, passed to every callable
+        stimulus so the whole session is rendered at one rate.
+    end_ramp : scalar
+        The fade to silence at the end of the session, in seconds. Like
+        the fade in at the start -- the first phase's ``ramp`` -- it is
+        taken from within the session rather than added to it, because
+        there is no neighbouring phase for it to overlap.
+    ramp_shape : string
+        ``'equal_power'``, the default, or ``'linear'``. See
+        :func:`_ramp_shape` for which to want when.
+    phases : list of StimulusPhase
+        The phases, in order. Normally built with :meth:`add`.
+
+    Examples
+    --------
+    >>> import music
+    >>> session = music.StimulationSession(end_ramp=0.05)
+    >>> session.add(music.binaural_beats, duration=0.2, beat_freq=10)
+    >>> session.add(music.isochronic_tones, duration=0.2, ramp=0.05,
+    ...             pulse_rate=6)
+    >>> session.duration
+    0.4
+    >>> session.render().shape
+    (2, 17640)
+
+    See Also
+    --------
+    music.Sequencer : notes scheduled at arbitrary offsets, which is the
+                      musical version of the same idea.
+    """
+
+    sample_rate: int = 44100
+    end_ramp: float = 0.0
+    ramp_shape: str = 'equal_power'
+    phases: List[StimulusPhase] = field(default_factory=list)
+
+    def add(self, stimulus: Stimulus, duration: float = 0.0,
+            ramp: float = 0.0, gain: float = 1.0, label: str = '',
+            **parameters: Any) -> None:
+        """Append a phase.
+
+        Parameters
+        ----------
+        stimulus : callable or array_like
+            The generator to render, or an already rendered sound.
+        duration : scalar
+            How long the phase lasts, in seconds. Required for a
+            callable; ignored for an array, which brings its own length.
+        ramp : scalar
+            The transition into this phase, in seconds.
+        gain : scalar
+            A factor applied to the phase before mixing.
+        label : string
+            A name for the phase.
+        **parameters
+            Passed to ``stimulus`` when it is a callable, so a phase is
+            written as the generator plus the arguments it would have
+            been called with.
+
+        Raises
+        ------
+        ValueError
+            If ``ramp`` or ``duration`` is negative, or if a callable
+            stimulus is given no duration -- it would render nothing,
+            and silently dropping a phase from a protocol is worse than
+            refusing it.
+        """
+        if duration < 0:
+            raise ValueError(f"duration cannot be negative, got {duration}")
+        if ramp < 0:
+            raise ValueError(f"ramp cannot be negative, got {ramp}")
+        if callable(stimulus) and not duration:
+            raise ValueError(
+                "a callable stimulus needs a duration; pass an already "
+                "rendered array to use its own length instead")
+        self.phases.append(
+            StimulusPhase(stimulus=stimulus, duration=duration, ramp=ramp,
+                          gain=gain, label=label, parameters=parameters))
+
+    def _layout(self):
+        """Where each phase starts and how long it is rendered, in samples.
+
+        Returns one ``(start, length, rise, fall)`` tuple per phase.
+        ``rise`` and ``fall`` are the crossfade lengths at its two
+        edges; consecutive phases overlap by exactly the shared ramp, so
+        one phase's fall lines up sample for sample with the next one's
+        rise.
+        """
+        count = len(self.phases)
+        ramps = [int(round(phase.ramp * self.sample_rate))
+                 for phase in self.phases]
+        ramps.append(int(round(self.end_ramp * self.sample_rate)))
+
+        layout = []
+        # Each boundary is rounded from the elapsed time rather than
+        # summed from per-phase roundings, which would drift by a sample
+        # every few phases and leave a long protocol the wrong length --
+        # the same error, in the same package, that phase integration
+        # made until 1.3.0. Phases given as arrays contribute exact
+        # sample counts, so they are carried separately.
+        elapsed = 0.0
+        from_arrays = 0
+        for index, phase in enumerate(self.phases):
+            # The opening and closing ramps overlap nothing, so they are
+            # carved out of the session rather than added to it, and the
+            # phases at the two ends are not extended.
+            half_in = 0 if index == 0 else ramps[index] // 2
+            half_out = (0 if index == count - 1
+                        else ramps[index + 1] - ramps[index + 1] // 2)
+            boundary = int(round(elapsed * self.sample_rate)) + from_arrays
+            if callable(phase.stimulus):
+                elapsed += phase.duration
+                span = (int(round(elapsed * self.sample_rate))
+                        + from_arrays - boundary)
+            else:
+                span = (len(np.atleast_2d(phase.stimulus)[0])
+                        - half_in - half_out)
+                from_arrays += span
+            layout.append((boundary - half_in, span + half_in + half_out,
+                           ramps[index], ramps[index + 1]))
+        return layout
+
+    def _render_phase(self, phase, length):
+        """One phase as an array of exactly `length` samples.
+
+        A callable is asked for that length directly. An array is
+        already the right length by construction -- :meth:`_layout`
+        derived the phase's span from it -- so it is only converted.
+        """
+        if callable(phase.stimulus):
+            rendered = phase.stimulus(number_of_samples=length,
+                                      sample_rate=self.sample_rate,
+                                      **phase.parameters)
+        else:
+            rendered = phase.stimulus
+        return np.asarray(rendered, dtype=np.float64) * phase.gain
+
+    @property
+    def duration(self) -> float:
+        """How long the session lasts, in seconds.
+
+        Measured from the layout rather than from the durations that
+        were asked for, so it reports what will actually be rendered.
+        """
+        layout = self._layout()
+        if not layout:
+            return 0.0
+        start, length, _, _ = layout[-1]
+        return (start + length) / self.sample_rate
+
+    def render(self) -> NDArray[np.float64]:
+        """Render every phase and mix them into one sound.
+
+        Returns
+        -------
+        ndarray
+            A one-dimensional array, or a ``(2, nsamples)`` one if any
+            phase is stereo -- a session that mixes binaural beats with
+            isochronic tones is stereo throughout, because the two
+            cannot share a channel layout and the binaural phase is the
+            one that would be destroyed by flattening.
+
+        Raises
+        ------
+        ValueError
+            If a callable stimulus returns a length other than the one
+            it was asked for. Every generator in this package honours
+            ``number_of_samples``; one that does not would silently
+            shift every phase after it.
+        """
+        layout = self._layout()
+        if not layout:
+            return np.zeros(0)
+
+        rendered = [self._render_phase(phase, length)
+                    for phase, (_, length, _, _) in zip(self.phases, layout)]
+        for sound, (_, length, _, _) in zip(rendered, layout):
+            if np.atleast_2d(sound).shape[1] != length:
+                raise ValueError(
+                    f"a stimulus rendered "
+                    f"{np.atleast_2d(sound).shape[1]} samples where "
+                    f"{length} were asked for")
+
+        stereo = any(sound.ndim == 2 for sound in rendered)
+        start, length, _, _ = layout[-1]
+        total = start + length
+        mix = np.zeros((2, total)) if stereo else np.zeros(total)
+
+        for sound, (start, length, rise, fall) in zip(rendered, layout):
+            envelope = np.ones(length)
+            rise = min(rise, length)
+            fall = min(fall, length - rise)
+            envelope[:rise] = _ramp_shape(rise, self.ramp_shape, True)
+            if fall:
+                envelope[length - fall:] = _ramp_shape(
+                    fall, self.ramp_shape, False)
+            if stereo and sound.ndim == 1:
+                sound = convert_to_stereo(sound)
+            mix[..., start:start + length] += sound * envelope
+        return mix
+
+    def write(self, filename: str, bit_depth: int = 16) -> None:
+        """Render the session and write it to a WAV file.
+
+        Parameters
+        ----------
+        filename : string
+            The path to write to.
+        bit_depth : integer
+            The bit depth of the samples written.
+        """
+        data = self.render()
+        if data.ndim == 1:
+            write_wav_mono(data, filename=filename,
+                           sample_rate=self.sample_rate,
+                           bit_depth=bit_depth)
+        else:
+            write_wav_stereo(data, filename=filename,
+                             sample_rate=self.sample_rate,
+                             bit_depth=bit_depth)
+
+    def __repr__(self) -> str:
+        if not self.phases:
+            return 'StimulationSession(empty)'
+        names = ', '.join(
+            phase.label or getattr(phase.stimulus, '__name__', 'array')
+            for phase in self.phases)
+        return (f'StimulationSession({len(self.phases)} phases, '
+                f'{self.duration:g} s: {names})')

--- a/music/stimulation/stimuli.py
+++ b/music/stimulation/stimuli.py
@@ -1,58 +1,21 @@
-"""Auditory stimuli for sensory-stimulation work.
-
-Each routine here renders one technique catalogued in **SSTIM**, the
-Sensory Stimulation Vocabulary developed in the W3C Sensory Stimulation
-Vocabulary Community Group. Every function names the SSTIM term it
-implements and links its IRI, so a rendered stimulus can be described in
-the same words a protocol, a dataset or a device uses:
-
-===============================  ==========================================
-Function                         SSTIM technique
-===============================  ==========================================
-:func:`binaural_beats`           ``sstim-v:techBinauralBeats``
-:func:`monaural_beats`           ``sstim-v:techMonauralBeats``
-:func:`isochronic_tones`         ``sstim-v:techIsochronicTones``
-:func:`amplitude_modulation`     ``sstim-v:techAmplitudeModulation``
-:func:`frequency_modulation`     ``sstim-v:techFrequencyModulation``
-===============================  ==========================================
-
-with ``sstim-v:`` standing for ``https://w3id.org/sstim/vocab#``. All five
-are members of ``sstim-v:TechniqueScheme``.
-
-One distinction SSTIM draws is worth carrying into the code, because it
-decides what a recording of the output contains. SSTIM records on each
-rendering mechanism whether it *puts a signal physically into the world*
-or whether the signal is *constructed by the nervous system*. Four of
-these five put a real modulation into the air, and a spectrum of the
-rendered audio shows it. :func:`binaural_beats` does not: each ear
-receives a steady tone, neither channel contains the beat, and the beat
-exists only for a listener hearing both. Measure the file and it is not
-there. Each docstring states which case it is.
-
-These routines build on the package's own primitives and follow its
-sample-by-sample model: a modulator is folded into the wavetable lookup
-rather than applied to a finished sound.
-
-References
-----------
-.. [1] Fabbri, Renato, et al. "Musical elements in the discrete-time
-       representation of sound." arXiv preprint arXiv:abs/1412.6853 (2017)
-.. [2] SSTIM, the Sensory Stimulation Vocabulary.
-       https://w3id.org/sstim
-"""
+"""The stimulus generators of :mod:`music.stimulation`."""
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from .core.synths.notes import note
-from .utils import WAVEFORM_SINE, _integrate_phase
+from ..core.filters.localization import _localize_positions
+from ..core.synths.noises import noise
+from ..core.synths.notes import note
+from ..utils import WAVEFORM_SINE, _integrate_phase
 
 __all__ = [
     'amplitude_modulation',
     'binaural_beats',
     'frequency_modulation',
     'isochronic_tones',
+    'modulated_noise',
     'monaural_beats',
+    'spatial_motion',
 ]
 
 
@@ -518,3 +481,258 @@ def frequency_modulation(
     index = _integrate_phase(instantaneous * length / sample_rate,
                              length).astype(np.int64)
     return table[index % length]
+
+
+def modulated_noise(noise_type: str | float = 'pink',
+                    modulation_freq: float = 10.0,
+                    modulation_depth: float = 1.0, duration: float = 2.0,
+                    min_freq: float = 15.0, max_freq: float = 15000.0,
+                    modulation_waveform_table: ArrayLike = WAVEFORM_SINE,
+                    number_of_samples: int = 0,
+                    sample_rate: int = 44100) -> NDArray[np.float64]:
+    """Modulate a band of noise: ``sstim-v:techBroadbandNoise``.
+
+    Broadband noise of a chosen colour, optionally amplitude-modulated at
+    a target rate. Unmodulated it is the continuous broadband stimulus
+    SSTIM catalogues as ``techBroadbandNoise`` [2]_, the vehicle for
+    stochastic resonance and for masking. Modulated it is also
+    ``sstim-v:techAmplitudeModulation`` [3]_, whose definition names a
+    carrier tone *or noise*; the noise carries no pitch of its own, so
+    the rate is all the listener has to lock to.
+
+    Parameters
+    ----------
+    noise_type : string or scalar
+        The colour of the noise, as :func:`music.noise` takes it: one of
+        ``"white"``, ``"pink"``, ``"brown"``, ``"blue"``, ``"violet"``,
+        ``"black"``, or a number of decibels of gain per octave. The
+        default is pink, which has equal energy per octave and is the
+        usual choice where a spectrum is meant to be even to the ear
+        rather than even in Hertz.
+    modulation_freq : scalar
+        The rate at which the amplitude is modulated, in Hertz. Zero
+        leaves the noise unmodulated, which is the plain broadband
+        stimulus.
+    modulation_depth : scalar
+        How deep the modulation goes, in ``[0, 1]``, as in
+        :func:`amplitude_modulation`.
+    duration : scalar
+        The duration in seconds.
+    min_freq : scalar
+        The lowest frequency present, in Hertz.
+    max_freq : scalar
+        The highest frequency present, in Hertz.
+    modulation_waveform_table : array_like
+        The table the modulator is looked up in, so the modulation need
+        not be sinusoidal.
+    number_of_samples : integer
+        The number of samples of the sound, taken instead of
+        ``duration`` when it is given.
+    sample_rate : integer
+        The sampling frequency in Hertz.
+
+    Returns
+    -------
+    ndarray
+        A mono sequence of PCM samples.
+
+    Raises
+    ------
+    ValueError
+        If ``modulation_depth`` is outside ``[0, 1]``, where the
+        envelope would go negative and invert the noise rather than
+        deepening the modulation.
+    ValueError
+        If ``modulation_freq`` is negative. A negative rate is the same
+        modulation as its absolute value for a symmetric table and a
+        different one otherwise, which makes it a mistake rather than a
+        choice.
+
+    Notes
+    -----
+    **The modulation is physically present** when there is one. With
+    ``modulation_freq`` at zero there is no modulation to be present or
+    absent, and the stimulus is a spectral one rather than a temporal
+    one: SSTIM types ``techBroadbandNoise`` as a non-entrainment
+    technique for exactly that reason, and nothing here entrains until
+    a rate is given.
+
+    The noise is synthesized once at full length and then shaped, rather
+    than being built per modulation period, so its spectrum is the one
+    :func:`music.noise` describes and the modulation does not repeat a
+    single block of samples.
+
+    See Also
+    --------
+    amplitude_modulation : the same envelope on a pitched carrier.
+    music.noise : the underlying colored noise, unshaped.
+
+    Examples
+    --------
+    >>> stimulus = modulated_noise(noise_type='pink', modulation_freq=10)
+    >>> stimulus.ndim
+    1
+
+    References
+    ----------
+    .. [1] Fabbri, Renato, et al. "Musical elements in the discrete-time
+           representation of sound." arXiv preprint arXiv:abs/1412.6853
+           (2017)
+    .. [2] SSTIM, ``techBroadbandNoise``.
+           https://w3id.org/sstim/vocab#techBroadbandNoise
+    .. [3] SSTIM, ``techAmplitudeModulation``.
+           https://w3id.org/sstim/vocab#techAmplitudeModulation
+
+    """
+    if not 0 <= modulation_depth <= 1:
+        raise ValueError(
+            f"modulation_depth must be in [0, 1], got {modulation_depth}")
+    if modulation_freq < 0:
+        raise ValueError(
+            f"modulation_freq cannot be negative, got {modulation_freq}")
+    count = _sample_count(duration, number_of_samples, sample_rate)
+    bed = noise(noise_type=noise_type, min_freq=min_freq,
+                max_freq=max_freq, number_of_samples=count,
+                sample_rate=sample_rate)
+    if not modulation_freq:
+        return np.asarray(bed, dtype=np.float64)
+    modulator = _oscillator(modulation_waveform_table, modulation_freq,
+                            count, sample_rate)
+    envelope = 1 - modulation_depth * (1 - modulator) / 2
+    return bed * envelope
+
+
+def spatial_motion(carrier_freq: float = 200.0, motion_rate: float = 0.2,
+                   duration: float = 2.0, theta1: float = 180.0,
+                   theta2: float = 0.0, dist: float = 0.1,
+                   sonic_vector: ArrayLike | None = None,
+                   waveform_table: ArrayLike = WAVEFORM_SINE,
+                   zeta: float = 0.215, air_temp: float = 20.0,
+                   number_of_samples: int = 0,
+                   sample_rate: int = 44100) -> NDArray[np.float64]:
+    """Orbit a source around the listener: ``sstim-v:techSpatialAuditory``.
+
+    A sound whose apparent position sweeps back and forth between two
+    azimuths at a chosen rate. SSTIM catalogues structured spatial
+    trajectories -- orbiting sources, lateral sweeps, spatial
+    alternation -- as ``techSpatialAuditory``, and distinguishes them
+    from simple left/right crossfades [2]_. This is on the right side of
+    that line: the two ears receive the interaural time and intensity
+    differences the geometry implies, computed per sample, not a pan
+    between two gains.
+
+    Parameters
+    ----------
+    carrier_freq : scalar
+        The frequency of the orbiting tone, in Hertz. Ignored when
+        ``sonic_vector`` is given.
+    motion_rate : scalar
+        How many round trips the source makes per second, in Hertz. One
+        cycle is a full there-and-back, so the source passes each
+        endpoint once per cycle.
+    duration : scalar
+        The duration in seconds.
+    theta1 : scalar
+        The azimuth the motion starts from, in degrees, measured from
+        the ear axis as everywhere else in this package: 0 is the right
+        ear's side, 180 the left. The default is a full crossing of the
+        head.
+    theta2 : scalar
+        The azimuth it travels to before returning, in degrees.
+    dist : scalar
+        The radius of the orbit, in meters.
+    sonic_vector : array_like or None
+        A mono sound to move instead of a synthesized tone, so a noise
+        bed or a rendered stimulus can be given a trajectory. When it is
+        given it sets the length, and ``duration``,
+        ``number_of_samples``, ``carrier_freq`` and ``waveform_table``
+        are not used.
+    waveform_table : array_like
+        The table the tone is looked up in.
+    zeta : scalar
+        The distance between the ears in meters.
+    air_temp : scalar
+        The temperature in Celsius used for calculating the speed of
+        sound.
+    number_of_samples : integer
+        The number of samples of the sound, taken instead of
+        ``duration`` when it is given.
+    sample_rate : integer
+        The sampling frequency in Hertz.
+
+    Returns
+    -------
+    ndarray
+        A ``(2, nsamples)`` array of stereo PCM samples.
+
+    Raises
+    ------
+    ValueError
+        If ``motion_rate`` is negative, which would reverse the
+        trajectory rather than slow it.
+
+    Notes
+    -----
+    **The motion is physically present**: the cues are in the signal,
+    and a recording of the output carries them.
+
+    The source travels along the arc at constant radius -- an orbit --
+    where :func:`music.localize_linear` travels the straight line
+    between its two endpoints, which is what makes that one linear. The
+    azimuth moves at a constant rate, so the trajectory is triangular in
+    angle and the source neither pauses nor lurches at the turns.
+
+    **There is no head-related transfer function here**, as there is
+    none anywhere in this package. Interaural time and intensity
+    differences place a source on the left-right axis and nothing else:
+    elevation, and whether the source is in front of or behind the
+    listener, are cues an HRTF carries and this does not. An orbit
+    rendered here is heard as a lateral sweep rather than as a circle
+    around the head, and an orbit between 90 and -90 degrees -- ahead
+    and behind -- renders no movement whatsoever, because those two
+    positions differ only in the cue that is missing.
+
+    See Also
+    --------
+    music.localize_linear : one straight pass, the primitive underneath.
+    music.note_with_doppler : a moving source synthesized rather than
+                              filtered, so it also shifts pitch.
+
+    Examples
+    --------
+    >>> stimulus = spatial_motion(carrier_freq=200, motion_rate=0.5)
+    >>> stimulus.shape[0]
+    2
+
+    References
+    ----------
+    .. [1] Fabbri, Renato, et al. "Musical elements in the discrete-time
+           representation of sound." arXiv preprint arXiv:abs/1412.6853
+           (2017)
+    .. [2] SSTIM, ``techSpatialAuditory``.
+           https://w3id.org/sstim/vocab#techSpatialAuditory
+
+    """
+    if motion_rate < 0:
+        raise ValueError(
+            f"motion_rate cannot be negative, got {motion_rate}")
+    if sonic_vector is None:
+        count = _sample_count(duration, number_of_samples, sample_rate)
+        source = note(freq=carrier_freq, waveform_table=waveform_table,
+                      number_of_samples=count, sample_rate=sample_rate)
+    else:
+        source = np.asarray(sonic_vector, dtype=np.float64)
+        count = len(source)
+    if count == 0:
+        return np.zeros((2, 0))
+
+    # The azimuth is triangular in time: one cycle runs theta1 to theta2
+    # and back, so `progress` rises from 0 to 1 and falls again.
+    samples = np.arange(count)
+    phase = (samples * motion_rate / sample_rate) % 1.0
+    progress = 1 - np.abs(1 - 2 * phase)
+    theta = np.radians(theta1 + (theta2 - theta1) * progress)
+
+    return _localize_positions(source, np.cos(theta) * dist,
+                               np.sin(theta) * dist, zeta, air_temp,
+                               sample_rate)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,13 @@ keywords = [
     'AM',
     'art',
     'audio',
+    'binaural beats',
     'campanology',
     'change ringing',
+    'entrainment',
     'filter',
     'FM',
-    'HRTF',
+    'isochronic tones',
     'LUT',
     'MASS',
     'multimedia',
@@ -74,11 +76,13 @@ keywords = [
     'permutation',
     'physics',
     'psychophysics',
+    'sensory stimulation',
     'signal processing',
     'sing',
     'sound',
     'spatialization',
     'speech',
+    'SSTIM',
     'synth'
 ]
 

--- a/tests/test_stimulation.py
+++ b/tests/test_stimulation.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 import music
-from music.stimulation import _oscillator, _sample_count
+from music.stimulation.stimuli import _oscillator, _sample_count
 from music.utils import WAVEFORM_SINE, WAVEFORM_SQUARE
 
 SR = 44100
@@ -32,6 +32,14 @@ def gate_of(signal, window=64):
     usable = len(signal) // window * window
     blocks = np.abs(signal[:usable]).reshape(-1, window)
     return blocks.max(axis=1) > 1e-6
+
+
+def envelope_strength_at(signal, target, sample_rate=SR):
+    """How much of the amplitude envelope sits at `target` Hertz."""
+    envelope = np.abs(signal)
+    spectrum = np.abs(np.fft.rfft(envelope - envelope.mean()))
+    freqs = np.fft.rfftfreq(len(signal), 1 / sample_rate)
+    return spectrum[np.argmin(np.abs(freqs - target))]
 
 
 def envelope_peak(signal, lo=2, hi=50, sample_rate=SR):
@@ -276,3 +284,174 @@ def test_the_modulator_can_be_driven_from_any_table():
         modulation_waveform_table=square)
     assert not np.allclose(sine, other)
     assert len(_oscillator(square, 10, 100, SR)) == 100
+
+
+# --------------------------------------------------------------------------
+# modulated noise -- a spectral stimulus until a rate is given
+# --------------------------------------------------------------------------
+
+def test_modulated_noise_puts_the_envelope_at_the_modulation_rate():
+    out = music.modulated_noise(modulation_freq=7, duration=2)
+    freq, _ = envelope_peak(out)
+    assert freq == pytest.approx(7, abs=0.6)
+
+
+def test_unmodulated_noise_is_the_bare_noise_bed():
+    """Zero rate is techBroadbandNoise, not amplitude modulation.
+
+    SSTIM types the two differently, and the difference has to be in
+    the signal: with no rate there is nothing at 7 Hz but the envelope
+    fluctuation any noise has. Seeded, because `noise` draws its phases
+    from `np.random` and an unseeded threshold is a flaky test.
+    """
+    np.random.seed(1)
+    flat = envelope_strength_at(
+        music.modulated_noise(modulation_freq=0, duration=2), 7)
+    np.random.seed(1)
+    modulated = envelope_strength_at(
+        music.modulated_noise(modulation_freq=7, duration=2), 7)
+    assert modulated > 5 * flat
+
+
+def test_noise_colour_changes_the_spectral_tilt():
+    """Brown falls off faster than white, which is what colour means."""
+    def tilt(signal):
+        spectrum = np.abs(np.fft.rfft(signal))
+        freqs = np.fft.rfftfreq(len(signal), 1 / SR)
+        band = (freqs >= 100) & (freqs <= 10000)
+        low = spectrum[band][:len(spectrum[band]) // 10].mean()
+        high = spectrum[band][-len(spectrum[band]) // 10:].mean()
+        return low / high
+
+    brown = music.modulated_noise(noise_type='brown', modulation_freq=0,
+                                  duration=1)
+    white = music.modulated_noise(noise_type='white', modulation_freq=0,
+                                  duration=1)
+    assert tilt(brown) > tilt(white)
+
+
+def test_full_depth_takes_the_noise_envelope_to_silence():
+    out = music.modulated_noise(modulation_freq=10, modulation_depth=1,
+                                duration=1)
+    assert np.abs(out).min() < 1e-9
+
+
+def test_zero_depth_leaves_the_noise_bed_alone():
+    """Depth zero and rate zero must render the same samples.
+
+    The two reach the answer by different branches -- one skips the
+    modulation, the other applies an envelope of ones -- and a bed that
+    differed between them would mean the envelope was not neutral.
+    """
+    kwargs = dict(noise_type='white', duration=0.5, number_of_samples=0)
+    np.random.seed(0)
+    flat = music.modulated_noise(modulation_freq=0, **kwargs)
+    np.random.seed(0)
+    zero_depth = music.modulated_noise(modulation_freq=10,
+                                       modulation_depth=0, **kwargs)
+    assert np.allclose(flat, zero_depth)
+
+
+def test_modulated_noise_rejects_a_depth_outside_the_unit_interval():
+    with pytest.raises(ValueError, match='modulation_depth'):
+        music.modulated_noise(modulation_depth=1.5)
+
+
+def test_modulated_noise_rejects_a_negative_rate():
+    with pytest.raises(ValueError, match='modulation_freq'):
+        music.modulated_noise(modulation_freq=-1)
+
+
+# --------------------------------------------------------------------------
+# spatial motion -- real interaural cues, and only the ones we have
+# --------------------------------------------------------------------------
+
+def test_spatial_motion_is_stereo_and_moves_between_the_channels():
+    """The energy balance must swing, and swing both ways."""
+    out = music.spatial_motion(motion_rate=1, duration=2, theta1=180,
+                               theta2=0)
+    assert out.shape[0] == 2
+    blocks = out.reshape(2, -1, 441)
+    balance = (np.abs(blocks[0]).max(axis=1)
+               - np.abs(blocks[1]).max(axis=1))
+    assert balance.max() > 0.05
+    assert balance.min() < -0.05
+
+
+def test_spatial_motion_sweeps_at_the_requested_rate():
+    """One round trip per cycle: the balance completes `rate` cycles."""
+    rate = 2
+    duration = 4
+    out = music.spatial_motion(motion_rate=rate, duration=duration,
+                               theta1=180, theta2=0)
+    window = 64
+    blocks = out[:, :out.shape[1] // window * window]
+    envelope = np.abs(blocks).reshape(2, -1, window).max(axis=2)
+    balance = envelope[0] - envelope[1]
+    spectrum = np.abs(np.fft.rfft(balance - balance.mean()))
+    freqs = np.fft.rfftfreq(len(balance), window / SR)
+    assert freqs[np.argmax(spectrum)] == pytest.approx(rate, abs=0.3)
+
+
+def test_a_still_source_is_the_same_as_localizing_it_once():
+    """Zero rate parks the source at theta1, where localize agrees.
+
+    The trajectory reduces to a fixed position, and a fixed position is
+    what `localize_linear` renders when its endpoints coincide. Sharing
+    `_localize_positions` is what makes them agree exactly rather than
+    approximately.
+    """
+    tone = music.note(freq=200, duration=0.5)
+    moving = music.spatial_motion(motion_rate=0, sonic_vector=tone,
+                                  theta1=45, theta2=-45)
+    still = music.localize_linear(tone, theta1=45, theta2=45, dist=0.1)
+    assert np.allclose(moving, still)
+
+
+def test_spatial_motion_can_move_a_sound_it_did_not_synthesize():
+    bed = music.modulated_noise(modulation_freq=0, duration=0.5)
+    out = music.spatial_motion(sonic_vector=bed, motion_rate=1)
+    assert out.shape == (2, len(bed))
+
+
+def test_spatial_motion_of_nothing_is_nothing():
+    out = music.spatial_motion(sonic_vector=np.zeros(0))
+    assert out.shape == (2, 0)
+
+
+def test_spatial_motion_rejects_a_negative_rate():
+    with pytest.raises(ValueError, match='motion_rate'):
+        music.spatial_motion(motion_rate=-1)
+
+
+def test_the_nearer_ear_is_never_delayed_past_the_farther_one():
+    """The cue must have the sign the geometry has.
+
+    A source to the left reaches the left ear first and louder. If the
+    trajectory were rendered with the ears swapped this test is the one
+    that catches it, and no test of shape or of rate would.
+    """
+    tone = music.note(freq=200, duration=0.3)
+    left = music.spatial_motion(motion_rate=0, sonic_vector=tone,
+                                theta1=180, theta2=180)
+    right = music.spatial_motion(motion_rate=0, sonic_vector=tone,
+                                 theta1=0, theta2=0)
+    assert np.abs(left[0]).max() > np.abs(left[1]).max()
+    assert np.abs(right[1]).max() > np.abs(right[0]).max()
+
+
+def test_ahead_and_behind_are_the_same_sound_because_there_is_no_hrtf():
+    """The gap the package documents, pinned as behaviour.
+
+    90 and -90 degrees are ahead and behind: same distance to both
+    ears, so the same interaural cues, so the same two channels. Front
+    from back is an HRTF cue and this package has no HRTF. If one is
+    ever added, this test fails, and that failure is the notice.
+    """
+    tone = music.note(freq=200, duration=0.2)
+    ahead = music.spatial_motion(motion_rate=0, sonic_vector=tone,
+                                 theta1=90, theta2=90)
+    behind = music.spatial_motion(motion_rate=0, sonic_vector=tone,
+                                  theta1=-90, theta2=-90)
+    assert np.array_equal(ahead, behind)
+    assert np.array_equal(ahead[0], ahead[1])

--- a/tests/test_stimulation_session.py
+++ b/tests/test_stimulation_session.py
@@ -1,0 +1,311 @@
+"""Sessions: a protocol's timing is a promise, and these tests hold it.
+
+A stimulation protocol is written as durations -- ten minutes here, five
+there -- and the person who wrote them down means them. A session that
+renders 9:58 because it spent two seconds crossfading has quietly
+changed the protocol. The first test in this file is the one that
+matters: the session lasts exactly the sum of its phases.
+
+The rest are about the joins. A cut between two stimuli is a step
+discontinuity, and a crossfade that dips is a hole; both are audible,
+and neither is in the protocol either.
+"""
+
+import numpy as np
+import pytest
+
+import music
+from music.stimulation.session import _ramp_shape
+
+SR = 44100
+
+
+def constant(number_of_samples=0, sample_rate=SR, level=1.0):
+    """A stimulus of a fixed level, so envelopes are readable directly."""
+    return np.full(number_of_samples, level)
+
+
+def stereo_constant(number_of_samples=0, sample_rate=SR, level=1.0):
+    """The same, in two channels."""
+    return np.full((2, number_of_samples), level)
+
+
+# --------------------------------------------------------------------------
+# timing -- the promise the class makes
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('ramp', [0.0, 0.1, 0.5])
+def test_a_session_lasts_the_sum_of_its_phases(ramp):
+    """Whatever the ramps, the arithmetic the author did still holds."""
+    session = music.StimulationSession()
+    session.add(constant, duration=1.0)
+    session.add(constant, duration=2.0, ramp=ramp)
+    session.add(constant, duration=0.5, ramp=ramp)
+    assert session.duration == pytest.approx(3.5)
+    assert len(session.render()) == int(round(3.5 * SR))
+
+
+def test_the_opening_and_closing_ramps_do_not_lengthen_the_session():
+    """They overlap nothing, so they are carved out rather than added."""
+    session = music.StimulationSession(end_ramp=0.25)
+    session.add(constant, duration=1.0, ramp=0.25)
+    assert session.duration == pytest.approx(1.0)
+
+
+def test_many_phases_do_not_accumulate_a_rounding_drift():
+    """Durations that do not land on whole samples, summed twenty times."""
+    session = music.StimulationSession()
+    for _ in range(20):
+        session.add(constant, duration=0.037, ramp=0.011)
+    expected = int(round(20 * 0.037 * SR))
+    assert len(session.render()) == expected
+
+
+def test_an_empty_session_renders_nothing_rather_than_failing():
+    session = music.StimulationSession()
+    assert session.duration == 0.0
+    assert len(session.render()) == 0
+
+
+# --------------------------------------------------------------------------
+# the joins
+# --------------------------------------------------------------------------
+
+def test_a_crossfade_leaves_no_gap():
+    """Whatever the shape, the level never reaches zero mid-session.
+
+    A gap would mean the two extents did not line up, which is the
+    failure that a crossfade is supposed to make impossible.
+    """
+    session = music.StimulationSession(ramp_shape='linear')
+    session.add(constant, duration=0.5)
+    session.add(constant, duration=0.5, ramp=0.2)
+    out = session.render()
+    assert out.min() > 0.99
+
+
+def test_equal_power_ramps_sum_in_quadrature():
+    """The property the default exists for, exactly rather than by ear.
+
+    Two different stimuli are uncorrelated, so their amplitudes add in
+    quadrature: holding the level across a transition means the two
+    gain curves square to one. A linear pair does not -- it squares to
+    0.5 in the middle, which is the 3 dB hole.
+    """
+    rising = _ramp_shape(512, 'equal_power', True)
+    falling = _ramp_shape(512, 'equal_power', False)
+    assert np.allclose(rising ** 2 + falling ** 2, 1.0)
+
+    linear_rise = _ramp_shape(512, 'linear', True)
+    linear_fall = _ramp_shape(512, 'linear', False)
+    assert (linear_rise ** 2 + linear_fall ** 2).min() == pytest.approx(0.5)
+
+
+def test_linear_ramps_sum_in_amplitude():
+    """And the property the other option exists for."""
+    rising = _ramp_shape(512, 'linear', True)
+    falling = _ramp_shape(512, 'linear', False)
+    assert np.allclose(rising + falling, 1.0)
+
+
+def test_linear_holds_the_level_for_correlated_phases():
+    """The case the other option is kept for.
+
+    Two phases that are the same sound add in amplitude rather than in
+    power, and there the linear pair is the flat one while equal power
+    bumps by about 3 dB.
+    """
+    def render(shape):
+        session = music.StimulationSession(ramp_shape=shape)
+        session.add(constant, duration=0.5)
+        session.add(constant, duration=0.5, ramp=0.2)
+        return session.render()
+
+    assert render('linear').max() == pytest.approx(1.0)
+    assert render('equal_power').max() == pytest.approx(np.sqrt(2), abs=0.01)
+
+
+def test_the_session_opens_from_silence_and_closes_to_it():
+    session = music.StimulationSession(end_ramp=0.1)
+    session.add(constant, duration=1.0, ramp=0.1)
+    out = session.render()
+    assert out[0] == pytest.approx(0.0)
+    assert out[-1] < 0.02
+    assert out[len(out) // 2] == pytest.approx(1.0)
+
+
+def test_without_a_ramp_a_phase_starts_at_full_level():
+    session = music.StimulationSession()
+    session.add(constant, duration=0.5)
+    out = session.render()
+    assert out[0] == pytest.approx(1.0)
+
+
+def test_a_ramp_longer_than_its_phase_is_clipped_to_it():
+    """A 1 s ramp into a 0.1 s phase cannot run past the phase.
+
+    It gives a shape rather than an IndexError or a silent phase.
+    """
+    session = music.StimulationSession(end_ramp=1.0)
+    session.add(constant, duration=0.1, ramp=1.0)
+    out = session.render()
+    assert len(out) == int(round(0.1 * SR))
+    assert np.all(np.isfinite(out))
+    assert out.max() > 0
+
+
+def test_ramp_shape_endpoints_are_silence_and_full():
+    rising = _ramp_shape(100, 'equal_power', True)
+    falling = _ramp_shape(100, 'equal_power', False)
+    assert rising[0] == pytest.approx(0.0)
+    assert rising[-1] > 0.99
+    assert falling[0] == pytest.approx(1.0)
+    assert falling[-1] < 0.02
+    assert len(_ramp_shape(0, 'equal_power', True)) == 0
+
+
+# --------------------------------------------------------------------------
+# channels -- a protocol mixes stimuli that do not agree on them
+# --------------------------------------------------------------------------
+
+def test_a_mono_session_stays_mono():
+    session = music.StimulationSession()
+    session.add(constant, duration=0.2)
+    assert session.render().ndim == 1
+
+
+def test_one_stereo_phase_makes_the_whole_session_stereo():
+    """Flattening is not an option: it is what destroys a binaural beat."""
+    session = music.StimulationSession()
+    session.add(constant, duration=0.2)
+    session.add(stereo_constant, duration=0.2, ramp=0.05)
+    out = session.render()
+    assert out.shape == (2, int(round(0.4 * SR)))
+    assert np.array_equal(out[0, :100], out[1, :100])
+
+
+def test_a_real_protocol_of_binaural_and_isochronic_phases():
+    """The case the class exists for, end to end."""
+    session = music.StimulationSession(end_ramp=0.05)
+    session.add(music.binaural_beats, duration=0.3, label='settle',
+                carrier_freq=200, beat_freq=10)
+    session.add(music.isochronic_tones, duration=0.3, ramp=0.1,
+                label='descend', carrier_freq=200, pulse_rate=6)
+    out = session.render()
+    assert out.shape == (2, int(round(0.6 * SR)))
+    assert np.abs(out).max() <= 1.0
+
+
+# --------------------------------------------------------------------------
+# phases given as arrays
+# --------------------------------------------------------------------------
+
+def test_an_array_phase_brings_its_own_length():
+    session = music.StimulationSession()
+    session.add(np.ones(SR // 2))
+    assert session.duration == pytest.approx(0.5)
+    assert len(session.render()) == SR // 2
+
+
+def test_an_array_phase_gives_up_its_share_of_the_ramps():
+    """The array is the whole extent, ramps included.
+
+    So its nominal span is what is left after the halves it lends to
+    its neighbours, and the session still lasts the sum of the spans.
+    """
+    session = music.StimulationSession()
+    session.add(constant, duration=0.5)
+    session.add(np.ones(SR // 2), ramp=0.1)
+    out = session.render()
+    assert len(out) == int(round(0.5 * SR)) + SR // 2 - int(round(0.05 * SR))
+    assert session.duration == pytest.approx(len(out) / SR)
+
+
+def test_a_stereo_array_phase_is_measured_by_its_second_axis():
+    session = music.StimulationSession()
+    session.add(np.ones((2, SR // 4)))
+    assert session.render().shape == (2, SR // 4)
+
+
+# --------------------------------------------------------------------------
+# gain, labels, and refusals
+# --------------------------------------------------------------------------
+
+def test_gain_scales_a_phase_before_it_is_mixed():
+    session = music.StimulationSession()
+    session.add(constant, duration=0.2, gain=0.25)
+    assert session.render().max() == pytest.approx(0.25)
+
+
+def test_parameters_reach_the_generator():
+    session = music.StimulationSession()
+    session.add(constant, duration=0.2, level=0.5)
+    assert session.render().max() == pytest.approx(0.5)
+
+
+def test_a_callable_without_a_duration_is_refused():
+    """Rendering nothing would drop a phase out of a protocol silently."""
+    session = music.StimulationSession()
+    with pytest.raises(ValueError, match='needs a duration'):
+        session.add(constant)
+
+
+@pytest.mark.parametrize('kwargs, match', [
+    ({'duration': -1}, 'duration'),
+    ({'duration': 1, 'ramp': -1}, 'ramp'),
+])
+def test_negative_times_are_refused(kwargs, match):
+    session = music.StimulationSession()
+    with pytest.raises(ValueError, match=match):
+        session.add(constant, **kwargs)
+
+
+def test_a_stimulus_that_ignores_number_of_samples_is_caught():
+    """It would shift every phase after it, so it is an error here.
+
+    `number_of_samples` was declared and ignored by two routines in
+    this package until 1.3.0, which is why this is checked rather than
+    assumed.
+    """
+    def wrong_length(number_of_samples=0, sample_rate=SR):
+        return np.ones(number_of_samples + 10)
+
+    session = music.StimulationSession()
+    session.add(wrong_length, duration=0.2)
+    with pytest.raises(ValueError, match='samples where'):
+        session.render()
+
+
+# --------------------------------------------------------------------------
+# output
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('stimulus, channels', [
+    (constant, 1),
+    (stereo_constant, 2),
+])
+def test_write_produces_a_readable_wav(tmp_path, stimulus, channels):
+    session = music.StimulationSession()
+    session.add(stimulus, duration=0.1)
+    path = tmp_path / 'session.wav'
+    session.write(str(path))
+    assert path.exists()
+    data = np.asarray(music.read_wav(str(path)))
+    assert (2 if data.ndim == 2 else 1) == channels
+
+
+def test_repr_names_the_phases_for_a_reader():
+    session = music.StimulationSession()
+    assert repr(session) == 'StimulationSession(empty)'
+    session.add(music.binaural_beats, duration=0.1)
+    session.add(np.ones(10), label='bed')
+    text = repr(session)
+    assert 'binaural_beats' in text
+    assert 'bed' in text
+    assert '2 phases' in text
+
+
+def test_an_unlabelled_array_phase_is_named_for_what_it_is():
+    session = music.StimulationSession()
+    session.add(np.ones(10))
+    assert 'array' in repr(session)


### PR DESCRIPTION
Closes #72.

1.3.0 shipped five generators, which was the easy half of #72. This adds the two stimuli the issue's own table lists, the session builder it asked for, and reconciles the metadata the issue said would be earned once the toolkit was real.

## The two missing stimuli

**`modulated_noise`** — broadband noise of a chosen colour, optionally modulated. SSTIM types the two cases differently and so does the code: with no rate it is `techBroadbandNoise`, a spectral stimulus that entrains nothing; with one it is also `techAmplitudeModulation`, whose definition names a carrier tone *or noise*. The distinction is in the signal, not just the label, and a test measures it.

**`spatial_motion`** — a source orbiting the listener at a chosen rate, rendering `techSpatialAuditory`, which SSTIM explicitly distinguishes from a left/right crossfade. This is on the right side of that line: interaural time and intensity differences computed per sample from the geometry. It will move a sound it did not synthesize, so a noise bed or an already-rendered stimulus can be given a trajectory. It shares its math with `localize_linear` through a new `_localize_positions` rather than carrying a second copy — `localize_linear` is bit-identical.

## The session builder

`StimulationSession`: phases in order, each with its own stimulus, duration and gain, joined by crossfades rather than cuts. The guarantee that matters is **the session lasts exactly the sum of its phase durations**. A ramp is taken half from the phase before and half from the phase after, so a transition is centred on the boundary rather than inserted between the phases and stretching a ten-minute protocol past ten minutes.

Boundaries are rounded from elapsed time rather than summed from per-phase roundings — the same drift the phase integration carried until 1.3.0, and a 20-phase session gets it wrong by 6 samples the naive way. Phases that disagree about channels promote the session to stereo, never flatten it, because flattening is what destroys a binaural beat. Crossfades are equal-power by default, since two different stimuli are uncorrelated and a linear pair digs a 3 dB hole at every transition; `ramp_shape='linear'` is there for the correlated case.

## A real defect found while testing

`localize_linear`'s docstring example read `theta1=90, theta2=-90` and called it "a pass from the left to the right". Azimuth here is measured from the ear axis — 0 is the right ear's side, 180 the left — so 90 and -90 are both on the median plane, ahead and behind. Both render the same distance to both ears, so **the example produced two identical channels and no movement at all**. Anyone who copied it was writing a mono sound into a stereo file.

Fixed, with the convention stated in the notes rather than left to be inferred. That ahead and behind are indistinguishable is not the defect — that is the HRTF gap the package documents everywhere — and a test now pins it, so adding an HRTF will announce itself by breaking that test. This is the kind of thing #67 exists to find.

## Metadata, reconciled in both directions

The MeSH music-therapy subjects are back in `.zenodo.json`, removed at 1.2.0 as a claim the code did not back and earned now, and `Intended Audience :: Healthcare Industry` is backed for the first time. Every MeSH identifier in the file was checked against the NLM lookup service — one I had added by following the pattern resolved to *Acquired Immunodeficiency Syndrome*, which is why they are all checked now rather than assumed.

Going the other way, `HRTF` is no longer a keyword in `pyproject.toml`. There is no HRTF here, `ASSESSMENT.md` calls its absence the largest genuine gap, and a keyword that surfaces the package in searches it can only disappoint is the same mistake the music-therapy subjects were.

`ASSESSMENT.md` is measured fresh per #70, and gains a section on what this metadata does and does not claim: the toolkit renders stimuli and tests them against the properties that define them, which is all a synthesis library can speak to. Whether they entrain anything is a question for the literature the SSTIM terms point at.

## Checks

586 tests (from 539), 100% coverage, `ruff` and `mypy` clean, docs build with `-W`, all 11 examples run except the one needing the external singing engine.

Note: this and the soundfile PR both add an `## [Unreleased]` block at the top of `CHANGELOG.md`, so whichever merges second will conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
