### PR TITLE
Read and write WAV with soundfile, and drop scipy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         # floors could drift into fiction without a single failure.
         run: |
           python -m pip install --upgrade pip
-          pip install 'colorama==0.4.6' 'numpy==1.26.4' 'scipy==1.12.0' \
+          pip install 'colorama==0.4.6' 'numpy==1.26.4' 'soundfile==0.12.1' \
                       'sympy==1.12' 'termcolor==2.4.0' 'matplotlib==3.7.1'
           pip install pytest pytest-cov
           pip install --no-deps -e .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ module, and every name it exported is still imported from the same
 place. `localize_linear` is bit-identical to 1.3.0; what changed there
 is the example in its docstring, which was wrong -- see below.
 
+**The dependency list changed**: `scipy` is gone and `soundfile` takes
+its place. Nothing in the public API changes shape, but an environment
+that installed `music` for scipy's sake will no longer get it.
+
 ### Added
 - **`music.modulated_noise`**, broadband noise of a chosen colour,
   optionally amplitude-modulated. Unmodulated it is the continuous
@@ -39,6 +43,18 @@ is the example in its docstring, which was wrong -- see below.
   since two different stimuli are uncorrelated and a linear pair would
   dig a 3 dB hole at every transition; `ramp_shape='linear'` is there
   for the correlated case, where it is the flat one instead.
+- **24-bit WAV, read and written.** `bit_depth=24` was a `ValueError`
+  because `scipy.io.wavfile` could not write it; libsndfile can, so it now
+  sits alongside 8, 16 and 32 in `BIT_DEPTHS` and in the round-trip tests.
+  It is the depth most audio work actually wants.
+- **An encoding this package cannot normalize is now refused by name.**
+  `read_wav` checks the file's declared subtype and raises
+  `unsupported WAV encoding: ...`. libsndfile will decode ADPCM and
+  companded formats to float quite happily, but those have no full scale
+  that this package's normalization is defined against, so being decoded
+  is not the same as being supported. The test that covers it writes a
+  real ADPCM file rather than mocking a reader's return value, which the
+  two tests it replaces had to do.
 
 ### Fixed
 - **`localize_linear`'s example moved nothing.** It read
@@ -59,6 +75,22 @@ is the example in its docstring, which was wrong -- see below.
   added, that test fails and the notice arrives with it.
 
 ### Changed
+- **WAV I/O moved from `scipy.io.wavfile` to `soundfile`, and scipy is no
+  longer a dependency.** It was a hard requirement carrying 102 MB and
+  imported for nothing but reading and writing WAV files -- two imports in
+  the whole package, one of them in `music.singing`. Measured on a clean
+  install of 3.12: **230 MB down to 133 MB**, and `import music` from
+  **~760 ms to ~580 ms**. Nothing in the public API changes shape, and the
+  quantisation contract is unchanged: `tests/test_fidelity.py` still pins
+  unity gain and the one-step round trip, now at four bit depths instead
+  of three.
+
+  `read_wav` got shorter rather than longer. libsndfile divides an integer
+  sample by its own full scale on the way to float, which is the
+  normalization the function used to compute by hand from the numpy dtype,
+  so the bit-depth arithmetic and the 8-bit midpoint correction are gone.
+  What is left is the part that is genuinely this package's decision: a
+  float WAV declares no full scale, so it is still scaled by its own peak.
 - **The MeSH music-therapy subjects are back in `.zenodo.json`**, along
   with `Acoustic Stimulation`. They were removed at 1.2.0 as a claim the
   code did not back; the toolkit backs it now, and the same reasoning

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,6 @@ autodoc_member_order = "bysource"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy", None),
 }
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/music/core/io.py
+++ b/music/core/io.py
@@ -4,19 +4,24 @@ import logging
 from typing import Any, Sequence
 
 import numpy as np
-from numpy.typing import ArrayLike, DTypeLike, NDArray
-from scipy.io import wavfile
+import soundfile as sf
+from numpy.typing import ArrayLike, NDArray
 from .functions import normalize_mono, normalize_stereo
 from .filters.adsr import adsr, adsr_stereo
 
-#: Integer dtype used to store samples at each supported bit depth.
-#: 8-bit WAV is unsigned with a midpoint offset; 16- and 32-bit are signed.
-#: These are the depths scipy.io.wavfile can write and read_wav can read back.
-BIT_DEPTHS: dict[int, DTypeLike] = {8: np.uint8, 16: np.int16, 32: np.int32}
+#: WAV encoding written at each supported bit depth. 8-bit WAV is unsigned
+#: with a midpoint offset, as the RIFF spec requires; libsndfile applies
+#: that offset itself, so nothing here has to.
+BIT_DEPTHS: dict[int, str] = {
+    8: "PCM_U8", 16: "PCM_16", 24: "PCM_24", 32: "PCM_32"}
+
+#: Encodings :func:`read_wav` understands: every depth that can be written,
+#: plus float files, which declare no full scale of their own.
+READABLE_SUBTYPES = frozenset(BIT_DEPTHS.values()) | {"FLOAT", "DOUBLE"}
 
 
-def _wav_dtype(bit_depth: int) -> DTypeLike:
-    """Return the numpy dtype for ``bit_depth``, or raise ValueError."""
+def _wav_subtype(bit_depth: int) -> str:
+    """Return the WAV encoding for ``bit_depth``, or raise ValueError."""
     try:
         return BIT_DEPTHS[bit_depth]
     except KeyError:
@@ -39,7 +44,7 @@ def _fade_pair(fades: Sequence[int] | int) -> tuple[int, int]:
 
 def _quantize(samples: NDArray[np.float64], bit_depth: int) -> NDArray[Any]:
     """Quantize samples in [-1, 1] to the integer encoding of a WAV file."""
-    dtype = _wav_dtype(bit_depth)
+    _wav_subtype(bit_depth)
     samples = np.asarray(samples, dtype=np.float64)
     if not np.isfinite(samples).all():
         raise ValueError(
@@ -59,10 +64,13 @@ def _quantize(samples: NDArray[np.float64], bit_depth: int) -> NDArray[Any]:
     full_scale = 2 ** (bit_depth - 1)
     scaled = np.clip(np.round(samples * full_scale), -full_scale,
                      full_scale - 1)
-    if bit_depth == 8:
-        # 8-bit WAV samples are unsigned, centred on 128 (RIFF spec).
-        scaled = scaled + full_scale
-    return scaled.astype(dtype)
+    # libsndfile takes samples in the next integer width up and keeps the
+    # high bits, so a sample narrower than its container is shifted into
+    # place -- 8-bit into an int16, 24-bit into an int32. It adds the
+    # unsigned midpoint 8-bit WAV needs on the way out. Exact both ways.
+    if bit_depth in (8, 24):
+        scaled = scaled * 256
+    return scaled.astype(np.int16 if bit_depth <= 16 else np.int32)
 
 
 def read_wav(filename: str) -> NDArray[np.float64]:
@@ -78,29 +86,25 @@ def read_wav(filename: str) -> NDArray[np.float64]:
     NDArray
         Values of the WAV file
     """
-    sample_rate, data = wavfile.read(filename)
-    logging.debug("read_wav dtype %s", data.dtype)
+    with sf.SoundFile(str(filename)) as handle:
+        subtype = handle.subtype
+        logging.debug("read_wav subtype %s", subtype)
+        if subtype not in READABLE_SUBTYPES:
+            raise ValueError(f"unsupported WAV encoding: {subtype}")
+        # libsndfile divides an integer sample by its own full scale on the
+        # way to float, which is the normalization this function used to do
+        # by hand, and it does it for 24-bit too.
+        data = handle.read(dtype="float64")
 
-    if np.issubdtype(data.dtype, np.integer):
-        bits = np.iinfo(data.dtype).bits
-        if bits not in BIT_DEPTHS:
-            raise ValueError(
-                f"unsupported integer WAV bit depth: {bits}"
-            )
-        norm = float(2 ** (bits - 1))
-        if not np.issubdtype(data.dtype, np.signedinteger):
-            # 8-bit WAV is stored unsigned around a midpoint; recentre it.
-            data = data.astype(np.float64) - 2 ** (bits - 1)
-    elif np.issubdtype(data.dtype, np.floating):
-        norm = float(np.max(np.abs(data)))
-        if norm == 0:
-            norm = 1.0
-    else:
-        raise ValueError(f"unsupported WAV data type: {data.dtype}")
+    if subtype in ("FLOAT", "DOUBLE"):
+        # A float WAV declares no full scale, so it is scaled by its own
+        # peak instead. An all-zero file has no peak to scale by.
+        peak = float(np.max(np.abs(data))) if data.size else 0.0
+        data = data / peak if peak else data
 
     if data.ndim == 2:
-        return data.astype(np.float64).T / norm
-    return data.astype(np.float64) / norm
+        return np.ascontiguousarray(data.T)
+    return data
 
 
 def write_wav_mono(
@@ -131,20 +135,20 @@ def write_wav_mono(
         Milliseconds of fade in and fade out (to avoid clicks), either as a
         pair or as a single value applied to both ends.
     bit_depth : integer
-        The number of bits in each sample of the final file: 8, 16 or 32.
-        Any other value raises ValueError.
+        The number of bits in each sample of the final file: 8, 16, 24 or
+        32. Any other value raises ValueError.
     remove_bias : boolean
         Whether to remove or not the bias (or offset)
 
     See Also
     --------
     normalize_mono : Normalizes an array to [-1,1]
-    write_wav_mono : Writes an array with the same arguments and order of them
-                     as scipy.io.wavfile.
+    write_wav_mono : Writes an array with the same arguments and order of
+                     them as soundfile.write.
     write_wav_stereo : Write a stereo file.
 
     """
-    _wav_dtype(bit_depth)  # reject an unsupported depth before doing work
+    subtype = _wav_subtype(bit_depth)  # reject a bad depth before the work
     if sonic_vector is None:
         sonic_vector = np.random.uniform(-1, 1, size=100000)
     result = normalize_mono(sonic_vector, remove_bias)
@@ -152,7 +156,8 @@ def write_wav_mono(
         f0, f1 = _fade_pair(fades)
         result = adsr(attack_duration=f0, sustain_level=0,
                       release_duration=f1, sonic_vector=result)
-    wavfile.write(filename, sample_rate, _quantize(result, bit_depth))
+    sf.write(str(filename), _quantize(result, bit_depth), sample_rate,
+             subtype=subtype)
 
 
 def write_wav_stereo(
@@ -182,8 +187,8 @@ def write_wav_stereo(
         Milliseconds of fade in and fade out (to avoid clicks), either as a
         pair or as a single value applied to both ends.
     bit_depth : integer
-        The number of bits in each sample of the final file: 8, 16 or 32.
-        Any other value raises ValueError.
+        The number of bits in each sample of the final file: 8, 16, 24 or
+        32. Any other value raises ValueError.
     remove_bias : boolean
         Whether to remove or not the bias (or offset)
     normalize_separately : boolean
@@ -196,7 +201,7 @@ def write_wav_stereo(
     write_wav_mono : Write a mono file.
 
     """
-    _wav_dtype(bit_depth)  # reject an unsupported depth before doing work
+    subtype = _wav_subtype(bit_depth)  # reject a bad depth before the work
     if sonic_vector is None:
         sonic_vector = np.random.uniform(-1, 1, size=(2, 100000))
     result = normalize_stereo(sonic_vector, remove_bias,
@@ -205,7 +210,8 @@ def write_wav_stereo(
         f0, f1 = _fade_pair(fades)
         result = adsr_stereo(attack_duration=f0, sustain_level=0,
                              release_duration=f1, sonic_vector=result)
-    wavfile.write(filename, sample_rate, _quantize(result, bit_depth).T)
+    sf.write(str(filename), _quantize(result, bit_depth).T, sample_rate,
+             subtype=subtype)
 
 
 def play_audio(

--- a/music/singing/perform.py
+++ b/music/singing/perform.py
@@ -5,7 +5,7 @@ import re
 import logging
 import shutil
 import subprocess
-from scipy.io import wavfile
+import soundfile as sf
 from music.core import normalize_mono
 from .paths import (ENGINE_MARKER, cache_dir, engine_dir, is_engine,
                     require_system_dependencies)
@@ -53,7 +53,8 @@ def sing(text="Mar-ry had a litt-le lamb",
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(f'Failed to build singing cache: {exc}') from exc
 
-    sample_rate, samples = wavfile.read(cache / 'achant.wav')
+    samples, sample_rate = sf.read(str(cache / 'achant.wav'),
+                                   dtype='float64')
     if sample_rate != 44100:
         raise RuntimeError(
             f'expected the engine to render at 44100 Hz, got {sample_rate}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = '>=3.10'
 dependencies = [
     'colorama >= 0.4.6',
     'numpy >= 1.26.4',
-    'scipy >= 1.12.0',
+    'soundfile >= 0.12.1',
     'sympy >= 1.12',
     'termcolor >= 2.4.0',
 ]

--- a/tests/test_abc_notation.py
+++ b/tests/test_abc_notation.py
@@ -97,8 +97,8 @@ def test_each_effect_selects_its_include(cache, effect, expected,
     (engine / "Makefile").write_text("all:\n\ttrue\n")
     monkeypatch.setattr(paths, "missing_requirements", lambda: [])
     monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
-    monkeypatch.setattr(perform.wavfile, "read",
-                        lambda path: (44100, np.zeros(4)))
+    monkeypatch.setattr(perform.sf, "read",
+                        lambda path, dtype=None: (np.zeros(4), 44100))
 
     perform.sing(effect=effect)
 
@@ -110,8 +110,8 @@ def test_the_language_and_transposition_reach_the_conf(cache, monkeypatch):
     (engine / "Makefile").write_text("all:\n\ttrue\n")
     monkeypatch.setattr(paths, "missing_requirements", lambda: [])
     monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
-    monkeypatch.setattr(perform.wavfile, "read",
-                        lambda path: (44100, np.zeros(4)))
+    monkeypatch.setattr(perform.sf, "read",
+                        lambda path, dtype=None: (np.zeros(4), 44100))
 
     perform.sing(lang="pt", transpose=-24)
 
@@ -125,8 +125,9 @@ def test_sing_returns_normalized_samples(cache, monkeypatch):
     (engine / "Makefile").write_text("all:\n\ttrue\n")
     monkeypatch.setattr(paths, "missing_requirements", lambda: [])
     monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
-    monkeypatch.setattr(perform.wavfile, "read",
-                        lambda path: (44100, np.array([0.0, 1.0, 2.0])))
+    monkeypatch.setattr(perform.sf, "read",
+                        lambda path, dtype=None: (np.array([0.0, 1.0, 2.0]),
+                                                  44100))
 
     out = perform.sing()
 
@@ -140,8 +141,8 @@ def test_sing_rejects_a_render_at_the_wrong_sample_rate(cache, monkeypatch):
     (engine / "Makefile").write_text("all:\n\ttrue\n")
     monkeypatch.setattr(paths, "missing_requirements", lambda: [])
     monkeypatch.setattr(perform.subprocess, "run", lambda *a, **k: None)
-    monkeypatch.setattr(perform.wavfile, "read",
-                        lambda path: (22050, np.zeros(4)))
+    monkeypatch.setattr(perform.sf, "read",
+                        lambda path, dtype=None: (np.zeros(4), 22050))
 
     with pytest.raises(RuntimeError, match="44100"):
         perform.sing()

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -190,7 +190,7 @@ def test_localize_delays_and_attenuates_the_far_ear_by_the_geometry():
 # Quantisation
 # --------------------------------------------------------------------------
 
-@pytest.mark.parametrize("bit_depth", [8, 16, 32])
+@pytest.mark.parametrize("bit_depth", [8, 16, 24, 32])
 def test_wav_round_trip_stays_within_one_quantisation_step(bit_depth,
                                                            tmp_path):
     """Writing and reading back may only cost the quantiser's own step.
@@ -210,7 +210,7 @@ def test_wav_round_trip_stays_within_one_quantisation_step(bit_depth,
     assert np.abs(restored - stored).max() <= step
 
 
-@pytest.mark.parametrize("bit_depth", [8, 16, 32])
+@pytest.mark.parametrize("bit_depth", [8, 16, 24, 32])
 def test_wav_round_trip_is_unity_gain(bit_depth, tmp_path):
     """Exactly representable levels must come back unchanged: the writer's
     scale and read_wav's divisor have to agree.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,26 +3,26 @@ import sys
 import numpy as np
 from unittest.mock import patch
 import pytest
-from scipy.io import wavfile
+import soundfile as sf
 
 import music
 
 
 def test_invalid_bit_depth_mono():
     with pytest.raises(ValueError):
-        music.write_wav_mono(np.zeros(10), filename="tmp.wav", bit_depth=24)
+        music.write_wav_mono(np.zeros(10), filename="tmp.wav", bit_depth=12)
 
 
 def test_invalid_bit_depth_stereo():
     with pytest.raises(ValueError):
         music.write_wav_stereo(np.zeros((2, 10)), filename="tmp.wav",
-                               bit_depth=24)
+                               bit_depth=12)
 
 
 def test_read_wav_16bit(tmp_path):
     path = tmp_path / "s16.wav"
     data = np.array([0, 1000, -1000], dtype=np.int16)
-    wavfile.write(path, 8000, data)
+    sf.write(str(path), data, 8000, subtype="PCM_16")
     out = music.read_wav(str(path))
     assert np.allclose(out, data.astype(np.float64) / (2 ** 15))
 
@@ -30,7 +30,7 @@ def test_read_wav_16bit(tmp_path):
 def test_read_wav_32bit(tmp_path):
     path = tmp_path / "s32.wav"
     data = np.array([0, 100000, -100000], dtype=np.int32)
-    wavfile.write(path, 8000, data)
+    sf.write(str(path), data, 8000, subtype="PCM_32")
     out = music.read_wav(str(path))
     assert np.allclose(out, data.astype(np.float64) / (2 ** 31))
 

--- a/tests/test_io_paths.py
+++ b/tests/test_io_paths.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from scipy.io import wavfile
+import soundfile as sf
 
 import music
 from music.core.io import _fade_pair
@@ -75,7 +75,8 @@ def test_the_writers_render_noise_when_given_nothing(writer, channels,
 
 def test_a_float_wav_is_scaled_by_its_own_peak(tmp_path):
     path = tmp_path / "float.wav"
-    wavfile.write(path, 8000, np.array([0.0, 0.25, -0.5], dtype=np.float32))
+    sf.write(str(path), np.array([0.0, 0.25, -0.5], dtype=np.float32), 8000,
+             subtype="FLOAT")
 
     out = music.read_wav(str(path))
 
@@ -85,25 +86,25 @@ def test_a_float_wav_is_scaled_by_its_own_peak(tmp_path):
 
 def test_an_all_zero_float_wav_does_not_divide_by_zero(tmp_path):
     path = tmp_path / "silent.wav"
-    wavfile.write(path, 8000, np.zeros(8, dtype=np.float32))
+    sf.write(str(path), np.zeros(8, dtype=np.float32), 8000,
+             subtype="FLOAT")
 
     assert np.array_equal(music.read_wav(str(path)), np.zeros(8))
 
 
-def test_an_unsupported_sample_format_is_reported(tmp_path):
-    path = tmp_path / "odd.wav"
-    with patch.object(wavfile, "read",
-                      return_value=(8000, np.zeros(4, dtype=np.complex64))):
-        with pytest.raises(ValueError, match="unsupported WAV data type"):
-            music.read_wav(str(path))
+def test_an_encoding_the_reader_does_not_support_is_reported(tmp_path):
+    """A real file in a real encoding, rather than a mocked return value.
 
-
-def test_an_unsupported_integer_depth_is_reported(tmp_path):
+    libsndfile will happily decode ADPCM, but a WAV whose samples are not
+    linear PCM has no full scale this package's normalization is defined
+    against, so it is refused rather than silently rescaled.
+    """
     path = tmp_path / "odd.wav"
-    with patch.object(wavfile, "read",
-                      return_value=(8000, np.zeros(4, dtype=np.int64))):
-        with pytest.raises(ValueError, match="unsupported integer WAV bit"):
-            music.read_wav(str(path))
+    sf.write(str(path), np.zeros(64, dtype=np.int16), 8000,
+             subtype="IMA_ADPCM")
+
+    with pytest.raises(ValueError, match="unsupported WAV encoding"):
+        music.read_wav(str(path))
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Supersedes #22, which proposed this swap in April 2025.

## Why

`scipy` was a hard dependency imported for nothing but WAV files: two `from scipy.io import wavfile` lines in the whole package, one of them in `music.singing`. Everything else it might have provided — `lfilter`'s convention among them — this package implements itself, and only mentions scipy in a comment.

Measured on clean virtualenvs, released 1.3.0 against this branch:

| | 1.3.0 (scipy) | this branch (soundfile) |
|---|---|---|
| installed size | 230 MB | **133 MB** |
| `import music`, warm | ~760 ms | **~580 ms** |

libsndfile ships as a wheel on every platform the CI matrix covers, and adds 3.1 MB.

## What it does to the code

`read_wav` came out **shorter**. libsndfile divides an integer sample by its own full scale on the way to float, which is exactly the normalization the function used to compute by hand from the numpy dtype — so the bit-depth arithmetic and the 8-bit midpoint correction are gone. What remains is the part that is genuinely a decision rather than arithmetic: a float WAV declares no full scale, so it is still scaled by its own peak.

**The quantiser is untouched, deliberately.** libsndfile would happily convert float to integer itself, but this package has a documented unity-gain contract with its own rounding and clipping, pinned by `tests/test_fidelity.py`, and handing that to a C library would have quietly changed what it promises. `_quantize` still produces the exact integer samples; libsndfile is only asked to store them. Samples narrower than their container are shifted into the high bits, which is how libsndfile wants them, and it is exact in both directions — verified per depth before any of this was written.

## Two things get better rather than merely equal

- **24-bit WAV, read and written.** `bit_depth=24` was a `ValueError` only because scipy could not write it. It is the depth most audio work actually wants, and the round-trip tests now cover four depths instead of three.
- **An encoding this package cannot normalize is refused by name.** libsndfile decodes ADPCM and companded formats quite happily, but they have no full scale that this package's normalization is defined against, and being decodable is not the same as being supported. `read_wav` now raises `unsupported WAV encoding: ...`. That test writes a real ADPCM file, where the two tests it replaces had to mock a reader's return value.

## Relationship to #22

The idea is @ksylvan's. The PR itself could not be merged: it was written against the April 2025 `io.py` and would have regressed today's typed 8/16/32-bit handling back to int16-only with `print()` debugging, and it bundled three unrelated changes alongside. This is the same swap done against current `master`, with the dependency actually dropped — which the original PR did not do, and which is where most of the benefit turns out to be.

## Worth recording for whoever looks next

With scipy gone, the biggest cost in `import music` is **sympy: roughly 470 ms and 73 MB**, pulled in by `music.structures.peals` for `sympy.combinatorics` alone. Same shape of finding as this one.

## Checks

540 tests, 100% coverage, `ruff` and `mypy` clean, docs build with `-W`. Verified in a clean virtualenv that the package installs and runs with no scipy present.

Note: this and #105 both add an `## [Unreleased]` block at the top of `CHANGELOG.md`, so whichever merges second will conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
