### PR TITLE
Stop importing a computer algebra system to make a sine wave

### DIFF
--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -1,8 +1,9 @@
 # Quality assessment and known limitations
 
-*A living record, not a point-in-time audit. Last measured **2026-09-02**,
-`music` 1.3.0 plus the unreleased sensory-stimulation toolkit: 40 modules,
-8,736 LOC package + 4,753 LOC tests, 88 names in the public API.*
+*A living record, not a point-in-time audit. Last measured **2026-09-03**,
+`music` 1.3.0 plus the unreleased stimulation toolkit and dependency work:
+40 modules, 8,790 LOC package + 4,821 LOC tests, 88 names in the public
+API.*
 
 The first version of this file graded the repository once, in August 2026,
 and was already stale four days later: it reported 125 tests at 61 % coverage
@@ -21,15 +22,16 @@ Every figure below came from running the code, not from reading it.
 
 | Check | Command | Result |
 |---|---|---|
-| Test suite | `pytest -q` | **586 passed**, 13 s |
-| Coverage | `pytest --cov=music --cov-fail-under=100` | **100 %** (2,288 stmts, 0 missed) |
+| Test suite | `pytest -q` | **599 passed**, 10 s |
+| Coverage | `pytest --cov=music --cov-fail-under=100` | **100 %** (2,292 stmts, 0 missed) |
 | Type check | `mypy music` | **clean**, 40 files |
 | Lint | `ruff check music tests examples tools conftest.py` | **clean** |
-| Lint, extended rule set | `ruff check --select ALL music` | 1,705 findings |
-| Annotation coverage | AST scan | **43 / 159 functions (27 %)** |
+| Lint, extended rule set | `ruff check --select ALL music` | 1,714 findings |
+| Annotation coverage | AST scan | **45 / 161 functions (28 %)** |
 | Docstring coverage | AST scan | **139 / 146 public defs (95 %)** |
 | Examples | run all 11 | **10 pass**, 1 needs the external singing engine |
 | Public API | `tests/test_public_api.py` | every export callable on its own defaults |
+| Import cost | `import music`, warm, 3.12 | **~185-290 ms**, and no sympy in `sys.modules` |
 | Archival subjects | NLM MeSH lookup, per identifier | every term in `.zenodo.json` resolves to the term it declares |
 
 `mypy` runs with `check_untyped_defs = true`, so it inspects function bodies
@@ -45,7 +47,7 @@ produced.
 | **Excellent** | Conceptual architecture; breadth of synthesis primitives; the release and archival process, which is reproducible and produces a citable DOI per version |
 | **Very good** | Test suite and its coverage gate; CI across Python 3.10–3.14 including a job pinned to the declared lower bounds |
 | **Good** | Curated flat public API; examples; published API reference; the sensory-stimulation toolkit, whose stimuli are each tested against the property that defines them rather than against their shape |
-| **Needs work** | Annotation coverage at 27 %; the `legacy/` subpackage; `core/functions.py` not yet reconciled with the MASS reference implementation |
+| **Needs work** | Annotation coverage at 28 %; the `legacy/` subpackage; `core/functions.py` not yet reconciled with the MASS reference implementation |
 
 ## Known limitations
 
@@ -108,14 +110,22 @@ either documented in the code or tracked in the issue list.
   tables; issue #3.
 - **matplotlib is an extra**, needed only by `PrimaryTables.draw_tables()`.
   Installing without it makes `import music` about 40 % faster.
+- **sympy is required, but no longer imported at `import music`.** The
+  permutation and change-ringing structures need it and cannot be written
+  without reimplementing a permutation group; two exported signatures take
+  and return sympy `Permutation` objects, so it is part of the public API
+  rather than an implementation detail. It is now reached through a
+  module-level `__getattr__`, so only callers who touch those structures
+  pay the roughly 400 ms it costs to import. It remains the largest single
+  dependency at 73 MB.
 
 ### Debt that is not breakage
 
-- **Annotation coverage is 27 %.** The package type-checks cleanly with
+- **Annotation coverage is 28 %.** The package type-checks cleanly with
   bodies inspected, so this is missing documentation of intent rather than
   missing safety.
-- **The extended lint set reports 1,705 findings** on `music/`, almost all
-  stylistic: 389 missing argument annotations, 330 quote-style, 92 missing
+- **The extended lint set reports 1,714 findings** on `music/`, almost all
+  stylistic: 389 missing argument annotations, 338 quote-style, 92 missing
   return annotations. The configured set — `E`, `W`, `F` — is clean. The
   gap between the two is a deliberate choice about which rules earn their
   noise, not an oversight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,28 @@ that installed `music` for scipy's sake will no longer get it.
   added, that test fails and the notice arrives with it.
 
 ### Changed
+- **`import music` no longer imports sympy**, and takes roughly a third
+  of the time it did: **~550-830 ms down to ~185-290 ms**, measured warm
+  on 3.12. The permutation and change-ringing structures --
+  `InterestingPermutations`, `Peals`, `PlainChanges`, `GenericPeal`,
+  `dist`, `transpose_permutation` -- are reached through a module-level
+  `__getattr__` rather than imported at the top, because importing
+  `sympy.combinatorics` runs `sympy/__init__.py` first and drags in
+  `sympy.polys` and the rest of the computer algebra system.
+
+  **Nothing about the API changes.** `music.Peals`,
+  `from music import Peals`, `help(music.Peals)` and `dir(music)` all
+  behave as before, and sympy loads on the first of them; a caller who
+  uses peals pays exactly what they paid, and a caller who only
+  synthesizes sound stops paying for them. sympy remains a required
+  dependency -- this is about when it is imported, not whether it is
+  installed. Removing it would break the structures outright and change
+  two signatures that take and return sympy `Permutation` objects.
+
+  `tests/test_import_cost.py` pins it, in a subprocess, because the way
+  this regresses is silent: one eager `from .structures import ...`
+  anywhere puts the cost back with nothing failing.
+
 - **WAV I/O moved from `scipy.io.wavfile` to `soundfile`, and scipy is no
   longer a dependency.** It was a hard requirement carrying 102 MB and
   imported for nothing but reading and writing WAV files -- two imports in

--- a/music/__init__.py
+++ b/music/__init__.py
@@ -1,6 +1,7 @@
 """Top-level package for basic audio synthesis utilities."""
 
 from importlib.metadata import PackageNotFoundError, version as _version
+from typing import TYPE_CHECKING, Any
 
 try:
     __version__ = _version("music")
@@ -86,18 +87,64 @@ from .stimulation import (
     monaural_beats,
     spatial_motion,
 )
-from .structures import (
-    dist,
-    GenericPeal,
-    InterestingPermutations,
-    Peals,
-    PlainChanges,
-    print_peal,
-    transpose_permutation
-)
 from .singing import get_engine, make_test_song, setup_engine
 from .legacy import Being, CanonicalSynth, IteratorSynth
 from .sequencer import Sequencer
+
+# The permutation and change-ringing structures are reached through
+# ``__getattr__`` rather than imported here, because importing them means
+# importing sympy, and importing sympy means importing the computer algebra
+# system it sits on -- ``sympy.polys`` and the rest. That cost about half of
+# ``import music`` (roughly 550-830 ms down to 225-320 ms measured warm on
+# 3.12) and was paid by everyone, including the majority of callers who only
+# synthesize sound and never touch a peal.
+#
+# Nothing about the API changes: ``music.Peals``, ``from music import Peals``
+# and ``help(music.Peals)`` all work, and sympy loads on the first of them.
+# ``music.structures`` can still be imported directly for the eager path.
+#
+# This is the same bargain matplotlib already gets here, one layer up: an
+# expensive dependency that a minority of the package needs should be paid
+# for by the callers who need it.
+_LAZY_STRUCTURES = frozenset({
+    'dist',
+    'GenericPeal',
+    'InterestingPermutations',
+    'Peals',
+    'PlainChanges',
+    'print_peal',
+    'transpose_permutation',
+})
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers and IDEs only
+    from .structures import (  # noqa: F401
+        dist,
+        GenericPeal,
+        InterestingPermutations,
+        Peals,
+        PlainChanges,
+        print_peal,
+        transpose_permutation,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve the structures exports on first use.
+
+    PEP 562. Anything not deferred raises ``AttributeError`` as it would
+    have without this hook, so a typo still fails the way a reader expects
+    rather than reporting an import error from somewhere else.
+    """
+    if name in _LAZY_STRUCTURES:
+        from . import structures
+        return getattr(structures, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Keep the deferred names visible to ``dir()`` and to tab completion."""
+    return sorted(set(globals()) | _LAZY_STRUCTURES)
+
 
 __all__ = [
     'WAVEFORMS',

--- a/tests/test_import_cost.py
+++ b/tests/test_import_cost.py
@@ -1,0 +1,66 @@
+"""What `import music` is allowed to cost.
+
+Importing the package should not import a computer algebra system. The
+permutation and change-ringing structures need sympy, and importing
+`sympy.combinatorics` runs `sympy/__init__.py` first, which pulls in
+`sympy.polys` and the rest -- about half of `import music`, paid by every
+caller including the majority who only synthesize sound.
+
+`music/__init__.py` defers those exports behind PEP 562 `__getattr__`.
+That is easy to undo by accident: one `from .structures import ...`
+added at the top of any eagerly imported module puts the cost straight
+back, with nothing failing. These tests are the thing that fails.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+import music
+
+
+def run(code):
+    """Run `code` in a clean interpreter and return its stdout."""
+    result = subprocess.run([sys.executable, "-c", code],
+                            capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def test_importing_music_does_not_import_sympy():
+    """The regression this guards is silent: everything still works, only
+    slower, so only a test notices."""
+    assert run("import sys, music; print('sympy' in sys.modules)") == "False"
+
+
+def test_touching_a_structure_imports_sympy():
+    """The other half of the bargain: deferred, not removed."""
+    assert run("import sys, music; music.Peals; "
+               "print('sympy' in sys.modules)") == "True"
+
+
+@pytest.mark.parametrize("name", sorted(music._LAZY_STRUCTURES))
+def test_every_deferred_name_resolves(name):
+    assert getattr(music, name) is not None
+
+
+def test_from_import_reaches_the_deferred_names():
+    """`from music import Peals` goes through __getattr__ too, and a
+    reader would not expect it to behave differently from an attribute."""
+    assert run("from music import Peals, dist; print(Peals.__name__)") \
+        == "Peals"
+
+
+def test_a_name_that_does_not_exist_still_raises_attribute_error():
+    """A typo must fail as a missing attribute, not as an import error
+    from somewhere the caller has never heard of."""
+    with pytest.raises(AttributeError, match="no attribute 'nonesuch'"):
+        music.nonesuch
+
+
+def test_dir_still_lists_the_deferred_names():
+    """Otherwise tab completion quietly loses half the structures API."""
+    listed = dir(music)
+    assert music._LAZY_STRUCTURES <= set(listed)
+    assert "note" in listed
+    assert listed == sorted(listed)


### PR DESCRIPTION
`import music` cost roughly 550–830 ms warm, and about two thirds of it was sympy — which nothing in the synthesis path touches. Importing `sympy.combinatorics` runs `sympy/__init__.py` first, so asking for a permutation group drags in `sympy.polys` and the rest of the computer algebra system. Every caller paid it, including the majority who only synthesize sound and will never ring a peal.

| `import music`, warm, 3.12 | |
|---|---|
| before | ~550–830 ms |
| after | **~185–290 ms** |
| after, then touching `music.Peals` | ~680 ms |

That last row is the point: peals users pay what they always paid, and nobody else does.

## What changed

The structures exports — `InterestingPermutations`, `Peals`, `PlainChanges`, `GenericPeal`, `dist`, `transpose_permutation` — resolve through a module-level `__getattr__` (PEP 562) instead of being imported at the top.

**Nothing about the API changes.** `music.Peals`, `from music import Peals`, `help(music.Peals)` and `dir(music)` all behave as before, and sympy loads on the first of them. `music.structures` is still importable directly for the eager path, and a `TYPE_CHECKING` block keeps the real types in front of mypy and IDEs rather than an `Any`.

## Why sympy stays a dependency

It is not scipy. The structures are built on `CyclicGroup`, `DihedralGroup`, `SymmetricGroup` and `AlternatingGroup`, and on `Permutation`'s ranking, cycle and array forms, and transposition decomposition. Writing that ourselves would mean reimplementing a permutation group, with change-ringing correctness resting on the details.

It is also not an implementation detail: `dist` *takes* a sympy `Permutation` and `transpose_permutation` *returns* one, so it is part of the public API and removing it would break callers. This PR changes **when** sympy is imported, not whether it is installed — and does not reduce the 73 MB it occupies on disk. Only making it an optional extra would do that, and that *would* be a breaking change for peals users.

## The test matters more than usual

`tests/test_import_cost.py` pins the behaviour in a subprocess, because the way this regresses is silent: one eager `from .structures import ...` added anywhere puts the whole cost back and **nothing fails**. It also covers the halves that are easy to lose while optimising the first — that the names still resolve, that `from music import ...` reaches them, that a typo still raises `AttributeError` rather than an import error from a module the caller has never heard of, and that `dir()` and tab completion still list them.

## Also

`ASSESSMENT.md` re-measured per #70 — it had gone stale again within a day of the last refresh, which is the failure mode that file exists to document about itself.

## Checks

599 tests, 100% coverage, `ruff` and `mypy` clean, docs build with `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
