### PR TITLE
Check what four routines render, not just how much of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ its place. Nothing in the public API changes shape, but an environment
 that installed `music` for scipy's sake will no longer get it.
 
 ### Added
+- **Value tests for four synthesis routines that had only their shape
+  checked** (issue #67, a first pass). `note_with_phase`,
+  `note_with_fm`, `note_with_glissando` and `trill` are now checked
+  against the equations their docstrings describe, sample for sample
+  where the routine is deterministic and spectrally where the claim is
+  about pitch.
+
+  The tests they join asserted a length and an amplitude range, which
+  silence and white noise both satisfy. `note_with_fm(max_fm_deviation=0)`
+  is now required to be a steady tone with nothing at the modulation
+  rate; a glissando between equal frequencies is required not to move;
+  a trill is required to alternate.
+
+  One test documents something worth knowing about table synthesis:
+  writing `(end - start) * samples / (count - 1)` and
+  `(end - start) * (samples / (count - 1))` differ in the last bit, and
+  since the lookup index is an integer floor, one bit is enough to
+  change a sample. The test reproduces the implementation's grouping
+  rather than tolerating the difference away.
+
 - **CI runs the examples**, through `tools/run_examples.py`, which also
   runs them locally in one command. Every example is expected to
   complete with a zero exit status unless it is named in the script's
@@ -125,6 +145,15 @@ that installed `music` for scipy's sake will no longer get it.
   two tests it replaces had to do.
 
 ### Fixed
+- **`trill` ignored `sample_rate`.** The note length and the loop bound
+  were hardcoded to 44100 while the argument was declared, documented,
+  and passed to `note()` -- so a trill asked for at 22050 Hz rendered two
+  seconds of audio for every one requested, at half the note rate. The
+  same defect `number_of_samples` had until 1.3.0: an argument honoured
+  in one place and ignored in another. Found by writing a test that
+  asked what the duration should be, where the old test asked only
+  whether some audio came back.
+
 - **`reverb` named the wrong thing when its phases disagreed.** A
   `first_phase_duration` longer than `duration` left two arrays of
   different lengths, and numpy reported a broadcast failure naming two

--- a/music/core/synths/notes.py
+++ b/music/core/synths/notes.py
@@ -1343,11 +1343,16 @@ def trill(freqs=(440, 440 * 2 ** (2 / 12)), notes_per_second=17, duration=5,
            representation of sound." arXiv preprint arXiv:abs/1412.6853 (2017)
 
     """
-    number_of_samples = 44100 / notes_per_second
+    # These were 44100 rather than sample_rate, which is declared,
+    # documented, and passed to note() below: a trill asked for at 22050
+    # rendered two seconds of audio for every one it was asked for, at
+    # half the note rate. The same defect number_of_samples had until
+    # 1.3.0 -- an argument honoured in one place and ignored in another.
+    number_of_samples = sample_rate / notes_per_second
     pointer = 0
     i = 0
     s = []
-    while pointer + number_of_samples < duration * 44100:
+    while pointer + number_of_samples < duration * sample_rate:
         ns = int(number_of_samples * (i + 1) - pointer)
         note_ = note(freqs[i % len(freqs)], number_of_samples=ns,
                      waveform_table=WAVEFORM_TRIANGULAR,

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -398,3 +398,192 @@ def test_both_paths_of_the_integrator_agree():
     difference = np.abs(short - blocked)
     across_the_fold = np.minimum(difference, TABLE_LENGTH - difference)
     assert across_the_fold.max() < 1e-6
+
+
+# --------------------------------------------------------------------------
+# Synthesis routines that had only their shape checked
+#
+# Each of these was covered by a test that asserted a length and a range,
+# which silence and white noise both satisfy. What follows checks the
+# samples against the equation the docstring describes, in the style of
+# test_note_matches_the_lookup_equation_sample_for_sample above.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("phase", [0.0, np.pi / 2, np.pi, 2 * np.pi])
+def test_note_with_phase_offsets_the_lookup_by_the_phase(phase):
+    """gamma = floor(phase * L / 2pi + n * f * L / fs), read mod L."""
+    freq, duration = 220.0, 0.05
+    produced = music.note_with_phase(freq=freq, duration=duration,
+                                     phase=phase,
+                                     waveform_table=WAVEFORM_SINE)
+
+    count = int(duration * SAMPLE_RATE)
+    length = len(WAVEFORM_SINE)
+    i0 = phase * length / (2 * np.pi)
+    gamma = (i0 + np.arange(count) * freq * length
+             / SAMPLE_RATE).astype(np.int64)
+    expected = WAVEFORM_SINE[gamma % length]
+
+    assert np.array_equal(produced, expected)
+
+
+def test_a_phase_of_zero_is_the_plain_note():
+    """The two routines describe the same sound when the phase is zero,
+    so they must render the same samples, not merely similar ones."""
+    plain = music.note(freq=220, duration=0.05,
+                       waveform_table=WAVEFORM_SINE)
+    phased = music.note_with_phase(freq=220, duration=0.05, phase=0,
+                                   waveform_table=WAVEFORM_SINE)
+    assert np.array_equal(plain, phased)
+
+
+def test_a_phase_of_a_quarter_turn_advances_a_quarter_of_the_table():
+    """The offset is in the table, not in time: a quarter turn starts the
+    lookup a quarter of the way through the period."""
+    length = len(WAVEFORM_SINE)
+    phased = music.note_with_phase(freq=SAMPLE_RATE / length, duration=0.05,
+                                   phase=np.pi / 2,
+                                   waveform_table=WAVEFORM_SINE)
+    assert phased[0] == WAVEFORM_SINE[length // 4]
+
+
+def test_note_with_fm_matches_the_modulated_lookup_equation():
+    """The modulator indexes its own table, sets the instantaneous
+    frequency, and that is integrated into the carrier's lookup."""
+    freq, fm, deviation, duration = 220.0, 30.0, 40.0, 0.05
+    produced = music.note_with_fm(freq=freq, duration=duration, fm=fm,
+                                  max_fm_deviation=deviation,
+                                  waveform_table=WAVEFORM_SINE,
+                                  fm_waveform_table=WAVEFORM_SINE)
+
+    count = int(duration * SAMPLE_RATE)
+    samples = np.arange(count)
+    modulator_length = len(WAVEFORM_SINE)
+    gamma_m = (samples * fm * modulator_length
+               / SAMPLE_RATE).astype(np.int64)
+    modulator = WAVEFORM_SINE[gamma_m % modulator_length]
+
+    instantaneous = freq + modulator * deviation
+    length = len(WAVEFORM_SINE)
+    gamma = _integrate_phase(instantaneous * length / SAMPLE_RATE,
+                             length).astype(np.int64)
+    expected = WAVEFORM_SINE[gamma % length]
+
+    assert np.array_equal(produced, expected)
+
+
+def test_fm_with_no_deviation_is_a_steady_tone():
+    """Zero deviation leaves the instantaneous frequency at `freq`, so
+    the modulator cannot appear in the output at all. The old test for
+    this routine asserted only a length and a range, which silence
+    satisfies."""
+    steady = music.note_with_fm(freq=440, duration=0.2, fm=7,
+                                max_fm_deviation=0,
+                                waveform_table=WAVEFORM_SINE)
+    spectrum = np.abs(np.fft.rfft(steady))
+    freqs = np.fft.rfftfreq(len(steady), 1 / SAMPLE_RATE)
+
+    assert freqs[np.argmax(spectrum)] == pytest.approx(440, abs=6)
+    # Nothing at the modulation rate, which a real deviation would put there.
+    at_modulator = spectrum[np.argmin(np.abs(freqs - 7))]
+    assert at_modulator < spectrum.max() / 1000
+
+
+def test_fm_sweeps_the_carrier_by_the_deviation_it_was_given():
+    """A slow, deep modulation puts energy across freq +/- deviation and
+    essentially none outside it."""
+    freq, deviation = 2000.0, 400.0
+    swept = music.note_with_fm(freq=freq, duration=1.0, fm=0.5,
+                               max_fm_deviation=deviation,
+                               waveform_table=WAVEFORM_SINE)
+    spectrum = np.abs(np.fft.rfft(swept))
+    freqs = np.fft.rfftfreq(len(swept), 1 / SAMPLE_RATE)
+
+    inside = ((freqs >= freq - deviation - 20)
+              & (freqs <= freq + deviation + 20))
+    band = (freqs > 100) & (freqs < 6000)
+    energy_inside = (spectrum[inside] ** 2).sum()
+    energy_in_band = (spectrum[band] ** 2).sum()
+    assert energy_inside / energy_in_band > 0.95
+
+
+@pytest.mark.parametrize("method, alpha", [("exp", 1), ("exp", 2),
+                                           ("lin", 1)])
+def test_glissando_follows_its_documented_frequency_law(method, alpha):
+    """Exponential glissando is f0 * (f1/f0) ** (n/N) ** alpha; linear is
+    the straight line between the two."""
+    start, end, duration = 220.0, 440.0, 0.05
+    produced = music.note_with_glissando(start_freq=start, end_freq=end,
+                                         duration=duration, alpha=alpha,
+                                         method=method,
+                                         waveform_table=WAVEFORM_SINE)
+
+    count = int(duration * SAMPLE_RATE)
+    samples = np.arange(count)
+    if method == "exp":
+        instantaneous = start * (end / start) ** (
+            (samples / (count - 1)) ** alpha)
+    else:
+        # Grouped as the implementation groups it. Association matters
+        # here: (end - start) * samples / (count - 1) and
+        # (end - start) * (samples / (count - 1)) differ in the last
+        # bit, and the lookup index is an integer floor, so one bit is
+        # enough to change a sample. That sensitivity is a property of
+        # table synthesis worth stating rather than tolerating away.
+        instantaneous = start + (end - start) * samples / (count - 1)
+    length = len(WAVEFORM_SINE)
+    gamma = _integrate_phase(instantaneous * length / SAMPLE_RATE,
+                             length).astype(np.int64)
+    expected = WAVEFORM_SINE[gamma % length]
+
+    assert np.array_equal(produced, expected)
+
+
+def test_a_glissando_between_equal_frequencies_is_a_plain_tone():
+    """Nothing to slide between, so the pitch must not move."""
+    flat = music.note_with_glissando(start_freq=440, end_freq=440,
+                                     duration=0.2,
+                                     waveform_table=WAVEFORM_SINE)
+    spectrum = np.abs(np.fft.rfft(flat))
+    freqs = np.fft.rfftfreq(len(flat), 1 / SAMPLE_RATE)
+    assert freqs[np.argmax(spectrum)] == pytest.approx(440, abs=6)
+
+
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+def test_trill_lasts_the_time_it_was_asked_for_at_any_rate(sample_rate):
+    """Regression: the note length and the loop bound were hardcoded to
+    44100 while `sample_rate` was declared, documented and passed to
+    note(). A trill asked for at 22050 rendered two seconds for every
+    one, at half the note rate. The old test asserted only that some
+    audio came back.
+    """
+    duration = 0.5
+    out = music.trill(freqs=[400, 500], notes_per_second=8,
+                      duration=duration, sample_rate=sample_rate)
+    assert len(out) == pytest.approx(duration * sample_rate,
+                                     abs=sample_rate / 8)
+
+
+def test_trill_alternates_between_the_frequencies_it_was_given():
+    """Each note in turn, which is what makes it a trill rather than a
+    sequence of identical notes."""
+    notes_per_second = 4
+    out = music.trill(freqs=[400, 1200], notes_per_second=notes_per_second,
+                      duration=1.0)
+    # Only whole notes are rendered, so the trill is three notes rather
+    # than four: the loop stops when the next one would not fit.
+    note_length = SAMPLE_RATE // notes_per_second
+    assert len(out) == 3 * note_length
+
+    def peak(signal):
+        spectrum = np.abs(np.fft.rfft(signal))
+        return np.fft.rfftfreq(len(signal), 1 / SAMPLE_RATE)[
+            np.argmax(spectrum)]
+
+    # A window inside each note, clear of the ADSR release at its end.
+    window = note_length // 2
+    peaks = [peak(out[i * note_length:i * note_length + window])
+             for i in range(3)]
+    assert peaks[0] == pytest.approx(400, abs=40)
+    assert peaks[1] == pytest.approx(1200, abs=60)
+    assert peaks[2] == pytest.approx(400, abs=40)


### PR DESCRIPTION
A first pass at #67, chosen by counting rather than by intuition.

## The measurement that motivated it

Classifying every test that renders audio by what it asserts about the audio:

| What it checks | Before |
|---|---|
| Against a closed-form equation | 11 |
| A spectral property (beat rate, envelope, pitch) | 16 |
| Compared to something, but not a derived expectation | 30 |
| **Only shape, length, range or finiteness** | **41** |
| Renders audio incidentally — really testing formats, errors, API | 47 |

So of roughly a hundred tests genuinely about rendered audio, about twenty-seven checked what the audio *is*. Forty-one checked only that it was the right length and contained no NaNs — assertions that **silence and white noise both satisfy**.

Worth saying plainly: 100% line coverage has been doing a lot of reputational work. Every line of `note_with_fm` was executed; almost nothing was checked about what came out of it.

## What this changes

`note_with_phase`, `note_with_fm` and `note_with_glissando` are reproduced **sample for sample** from the equations their docstrings describe, in the style `test_note_matches_the_lookup_equation_sample_for_sample` already used for `note()`. Where the claim is about pitch rather than samples, the test is spectral:

- `note_with_fm(max_fm_deviation=0)` must be a steady tone with nothing at the modulation rate
- a glissando between equal frequencies must not move
- a trill must actually alternate between its frequencies

## It found a bug on the first try

**`trill` ignored `sample_rate`.** The note length and loop bound were hardcoded to 44100 while the argument was declared, documented, and passed through to `note()`:

```
before:  22050 Hz -> 44100 samples = 2.000 s   (asked for 1.0)
after:   22050 Hz -> 22050 samples = 1.000 s
```

A trill asked for at 22050 rendered two seconds for every one, at half the note rate. Exactly the defect `number_of_samples` had until 1.3.0 — an argument honoured in one place and ignored in another. The old test asserted that some audio came back, which it did.

## One test worth reading

`(end - start) * samples / (count - 1)` and `(end - start) * (samples / (count - 1))` differ in the last bit, and the lookup index is an integer floor, so **one bit is enough to change a sample**. The glissando test reproduces the implementation's grouping rather than loosening the assertion to `allclose`, because that sensitivity is a property of table synthesis rather than noise to tolerate away.

## Scope

Four routines. This is a first pass, not #67 finished — the audit script that produced the table above is how the remaining ones should be chosen, and the `localize` family, `adsr`, `loud`/`louds`, `reverb` and `stretches` are the obvious next batch.

## Checks

811 tests (from 794), 100% coverage, `ruff` and `mypy` clean, docs build with `-W`, all examples run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
